### PR TITLE
ci: add OPA-based rego testing

### DIFF
--- a/.github/workflows/test-rego.yml
+++ b/.github/workflows/test-rego.yml
@@ -1,0 +1,23 @@
+name: "Test Rego Policies"
+
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [latest]
+    steps:
+      - name: Setup OPA
+        uses: open-policy-agent/setup-opa@v2
+        with:
+          version: ${{ matrix.version }}
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+      - name: Run OPA tests
+        run: |
+          opa test -v .


### PR DESCRIPTION
This PR adds a GitHub Action workflow to run `opa test -v .` command given the content of this repository.

Signed-off-by: Takashi Yoneuchi <takashi.yoneuchi@shift-js.info>