### PR TITLE
feat: validate managed decision payloads

### DIFF
--- a/assertion/typing.rego
+++ b/assertion/typing.rego
@@ -1,0 +1,29 @@
+package shisho.assertion
+
+import data.shisho.primitive
+
+is_type(x, ty, val_name) := false {
+	not primitive.is_type(x, ty)
+	print(concat("", ["validation error: type mismatch: ", val_name, " (expected ", ty, ", got ", type_name(x), ")"]))
+} else := true
+
+is_set_or_array(x, val_name) := false {
+	not primitive.is_set_or_array(x)
+	print(concat("", ["validation error: type mismatch: ", val_name, " (expected set or array, got ", type_name(x), ")"]))
+} else := true
+
+is_set_or_object(x, val_name) := false {
+	not primitive.is_set_or_object(x)
+	print(concat("", ["validation error: type mismatch: ", val_name, " (expected set or object, got ", type_name(x), ")"]))
+} else := true
+
+has_key(x, key, val_name) := false {
+	not primitive.has_key(x, key)
+	print(concat("", ["validation error: ", val_name, " is missing key: ", key]))
+} else := true
+
+has_typed_key(x, key, ty, val_name) := false {
+	not has_key(x, key, val_name)
+} else := is_set_or_array(x[key], concat("", [val_name, "[", key, "]"])) {
+	ty == "array"
+} else := is_type(x[key], ty, concat("", [val_name, "[", key, "]"]))

--- a/decision/aws/alb/alb_delete_protection.gen.rego
+++ b/decision/aws/alb/alb_delete_protection.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.alb
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure Application Load Balancer deletion protection is enabled
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_alb_delete_protection".
 delete_protection(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": delete_protection_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ delete_protection_allowed(h) {
 #     "deletion_protection_enabled": false,
 #   }
 #   ```
-delete_protection_payload(edata) = x {
+delete_protection_payload(edata) := x {
+	delete_protection_payload_assert(edata, "<the argument to delete_protection_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+delete_protection_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "deletion_protection_enabled", concat("", [hint, ".", "deletion_protection_enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [delete_protection_payload_assert_deletion_protection_enabled(edata, "deletion_protection_enabled", concat("", [hint, ".", "deletion_protection_enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+delete_protection_payload_assert_deletion_protection_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/aws/alb/alb_desync_mitigation.gen.rego
+++ b/decision/aws/alb/alb_desync_mitigation.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.alb
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure Application Load Balancers mitigate HTTP desync attacks
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_alb_desync_mitigation".
 desync_mitigation(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": desync_mitigation_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ desync_mitigation_allowed(h) {
 #     "desync_mitigation_mode": "example",
 #   }
 #   ```
-desync_mitigation_payload(edata) = x {
+desync_mitigation_payload(edata) := x {
+	desync_mitigation_payload_assert(edata, "<the argument to desync_mitigation_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+desync_mitigation_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "desync_mitigation_mode", concat("", [hint, ".", "desync_mitigation_mode"]))]
+	every c in key_checks { c }
+
+	value_checks := [desync_mitigation_payload_assert_desync_mitigation_mode(edata, "desync_mitigation_mode", concat("", [hint, ".", "desync_mitigation_mode"]))]
+	every c in value_checks { c }
+} else := false
+
+desync_mitigation_payload_assert_desync_mitigation_mode(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/alb/alb_invalid_header_handling.gen.rego
+++ b/decision/aws/alb/alb_invalid_header_handling.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.alb
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure Application Load Balancers drop invalid HTTP headers
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_alb_invalid_header_handling".
 invalid_header_handling(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": invalid_header_handling_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ invalid_header_handling_allowed(h) {
 #     "invalid_header_mitigation_enabled": false,
 #   }
 #   ```
-invalid_header_handling_payload(edata) = x {
+invalid_header_handling_payload(edata) := x {
+	invalid_header_handling_payload_assert(edata, "<the argument to invalid_header_handling_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+invalid_header_handling_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "invalid_header_mitigation_enabled", concat("", [hint, ".", "invalid_header_mitigation_enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [invalid_header_handling_payload_assert_invalid_header_mitigation_enabled(edata, "invalid_header_mitigation_enabled", concat("", [hint, ".", "invalid_header_mitigation_enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+invalid_header_handling_payload_assert_invalid_header_mitigation_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/aws/cloudfront/cloudfront_default_root_object.gen.rego
+++ b/decision/aws/cloudfront/cloudfront_default_root_object.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.cloudfront
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure CloudFront distributions have a default root object
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_cloudfront_default_root_object".
 default_root_object(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": default_root_object_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ default_root_object_allowed(h) {
 #     "default_root_object": "example",
 #   }
 #   ```
-default_root_object_payload(edata) = x {
+default_root_object_payload(edata) := x {
+	default_root_object_payload_assert(edata, "<the argument to default_root_object_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+default_root_object_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "default_root_object", concat("", [hint, ".", "default_root_object"]))]
+	every c in key_checks { c }
+
+	value_checks := [default_root_object_payload_assert_default_root_object(edata, "default_root_object", concat("", [hint, ".", "default_root_object"]))]
+	every c in value_checks { c }
+} else := false
+
+default_root_object_payload_assert_default_root_object(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/cloudfront/cloudfront_origin_transport.gen.rego
+++ b/decision/aws/cloudfront/cloudfront_origin_transport.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.cloudfront
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that connections to CloudFront distribution origins are forced to use HTTPS
 # You can emit this decision as follows:
@@ -22,7 +26,7 @@ import data.shisho
 #     "allowed": allowed,
 #     "subject": subject,
 #     "payload": shisho.decision.aws.cloudfront.origin_transport_payload({
-#       "origins": [{"id": "example", "domain_id": "example", "protocol_policy": "example", "ssl_protocols": ["example"]}],
+#       "origins": [{"id": "example", "domain_name": "example", "protocol_policy": "example", "ssl_protocols": ["example"]}],
 #     }),
 #   })
 # }
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_cloudfront_origin_transport".
 origin_transport(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": origin_transport_header({
 			"allowed": d.allowed,
@@ -88,14 +93,85 @@ origin_transport_allowed(h) {
 #   Emits a decision entry describing the detail of a decision decision.api.shisho.dev/v1beta:aws_cloudfront_origin_transport
 #
 #   The parameter `data` is an object with the following fields: 
-#   - origins: {"id": string, "domain_id": string, "protocol_policy": string, "ssl_protocols": string}
+#   - origins: {"id": string, "domain_name": string, "protocol_policy": string, "ssl_protocols": string}
 #
 #   For instance, `data` can take the following value:
 #   ```rego
 #   {
-#     "origins": [{"id": "example", "domain_id": "example", "protocol_policy": "example", "ssl_protocols": ["example"]}],
+#     "origins": [{"id": "example", "domain_name": "example", "protocol_policy": "example", "ssl_protocols": ["example"]}],
 #   }
 #   ```
-origin_transport_payload(edata) = x {
+origin_transport_payload(edata) := x {
+	origin_transport_payload_assert(edata, "<the argument to origin_transport_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+origin_transport_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "origins", concat("", [hint, ".", "origins"]))]
+	every c in key_checks { c }
+
+	value_checks := [origin_transport_payload_assert_origins(edata, "origins", concat("", [hint, ".", "origins"]))]
+	every c in value_checks { c }
+} else := false
+
+origin_transport_payload_assert_origins(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [origin_transport_payload_assert_origins_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+origin_transport_payload_assert_origins_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "id", "string", hint),
+		assertion.has_typed_key(x[key], "domain_name", "string", hint),
+		assertion.has_typed_key(x[key], "protocol_policy", "string", hint),
+		assertion.has_typed_key(x[key], "ssl_protocols", "array", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		origin_transport_payload_assert_origins_element_id(x[key], "id", concat("", [hint, ".", "id"])),
+		origin_transport_payload_assert_origins_element_domain_name(x[key], "domain_name", concat("", [hint, ".", "domain_name"])),
+		origin_transport_payload_assert_origins_element_protocol_policy(x[key], "protocol_policy", concat("", [hint, ".", "protocol_policy"])),
+		origin_transport_payload_assert_origins_element_ssl_protocols(x[key], "ssl_protocols", concat("", [hint, ".", "ssl_protocols"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+origin_transport_payload_assert_origins_element_domain_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+origin_transport_payload_assert_origins_element_id(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+origin_transport_payload_assert_origins_element_protocol_policy(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+origin_transport_payload_assert_origins_element_ssl_protocols(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [origin_transport_payload_assert_origins_element_ssl_protocols_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+origin_transport_payload_assert_origins_element_ssl_protocols_element(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/cloudfront/cloudfront_origin_transport_version.gen.rego
+++ b/decision/aws/cloudfront/cloudfront_origin_transport_version.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.cloudfront
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that HTTPS connections to CloudFront distribution origins use secure SSL/TLS protocols
 # You can emit this decision as follows:
@@ -22,7 +26,7 @@ import data.shisho
 #     "allowed": allowed,
 #     "subject": subject,
 #     "payload": shisho.decision.aws.cloudfront.origin_transport_version_payload({
-#       "origins": [{"id": "example", "domain_id": "example", "protocol_policy": "example", "ssl_protocols": ["example"]}],
+#       "origins": [{"id": "example", "domain_name": "example", "protocol_policy": "example", "ssl_protocols": ["example"]}],
 #     }),
 #   })
 # }
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_cloudfront_origin_transport_version".
 origin_transport_version(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": origin_transport_version_header({
 			"allowed": d.allowed,
@@ -88,14 +93,85 @@ origin_transport_version_allowed(h) {
 #   Emits a decision entry describing the detail of a decision decision.api.shisho.dev/v1beta:aws_cloudfront_origin_transport_version
 #
 #   The parameter `data` is an object with the following fields: 
-#   - origins: {"id": string, "domain_id": string, "protocol_policy": string, "ssl_protocols": string}
+#   - origins: {"id": string, "domain_name": string, "protocol_policy": string, "ssl_protocols": string}
 #
 #   For instance, `data` can take the following value:
 #   ```rego
 #   {
-#     "origins": [{"id": "example", "domain_id": "example", "protocol_policy": "example", "ssl_protocols": ["example"]}],
+#     "origins": [{"id": "example", "domain_name": "example", "protocol_policy": "example", "ssl_protocols": ["example"]}],
 #   }
 #   ```
-origin_transport_version_payload(edata) = x {
+origin_transport_version_payload(edata) := x {
+	origin_transport_version_payload_assert(edata, "<the argument to origin_transport_version_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+origin_transport_version_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "origins", concat("", [hint, ".", "origins"]))]
+	every c in key_checks { c }
+
+	value_checks := [origin_transport_version_payload_assert_origins(edata, "origins", concat("", [hint, ".", "origins"]))]
+	every c in value_checks { c }
+} else := false
+
+origin_transport_version_payload_assert_origins(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [origin_transport_version_payload_assert_origins_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+origin_transport_version_payload_assert_origins_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "id", "string", hint),
+		assertion.has_typed_key(x[key], "domain_name", "string", hint),
+		assertion.has_typed_key(x[key], "protocol_policy", "string", hint),
+		assertion.has_typed_key(x[key], "ssl_protocols", "array", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		origin_transport_version_payload_assert_origins_element_id(x[key], "id", concat("", [hint, ".", "id"])),
+		origin_transport_version_payload_assert_origins_element_domain_name(x[key], "domain_name", concat("", [hint, ".", "domain_name"])),
+		origin_transport_version_payload_assert_origins_element_protocol_policy(x[key], "protocol_policy", concat("", [hint, ".", "protocol_policy"])),
+		origin_transport_version_payload_assert_origins_element_ssl_protocols(x[key], "ssl_protocols", concat("", [hint, ".", "ssl_protocols"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+origin_transport_version_payload_assert_origins_element_domain_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+origin_transport_version_payload_assert_origins_element_id(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+origin_transport_version_payload_assert_origins_element_protocol_policy(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+origin_transport_version_payload_assert_origins_element_ssl_protocols(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [origin_transport_version_payload_assert_origins_element_ssl_protocols_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+origin_transport_version_payload_assert_origins_element_ssl_protocols_element(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/cloudtrail/cloudtrail_log_bucket_accessibility.gen.rego
+++ b/decision/aws/cloudtrail/cloudtrail_log_bucket_accessibility.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.cloudtrail
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure the S3 bucket for CloudTrail logs is not publicly accessible
 # You can emit this decision as follows:
@@ -22,7 +26,7 @@ import data.shisho
 #     "allowed": allowed,
 #     "subject": subject,
 #     "payload": shisho.decision.aws.cloudtrail.log_bucket_accessibility_payload({
-#       "acl_rules": [{"grantee_uri": "example", "permission": "example"}],
+#       "acl_rules": [{"grantee_url": "example", "permission": "example"}],
 #       "bucket_name": "example",
 #       "bucket_policy_document": "example",
 #     }),
@@ -36,6 +40,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_cloudtrail_log_bucket_accessibility".
 log_bucket_accessibility(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": log_bucket_accessibility_header({
 			"allowed": d.allowed,
@@ -90,18 +95,80 @@ log_bucket_accessibility_allowed(h) {
 #   Emits a decision entry describing the detail of a decision decision.api.shisho.dev/v1beta:aws_cloudtrail_log_bucket_accessibility
 #
 #   The parameter `data` is an object with the following fields: 
-#   - acl_rules: {"grantee_uri": string, "permission": string}
+#   - acl_rules: {"grantee_url": string, "permission": string}
 #   - bucket_name: string
 #   - bucket_policy_document: string
 #
 #   For instance, `data` can take the following value:
 #   ```rego
 #   {
-#     "acl_rules": [{"grantee_uri": "example", "permission": "example"}],
+#     "acl_rules": [{"grantee_url": "example", "permission": "example"}],
 #     "bucket_name": "example",
 #     "bucket_policy_document": "example",
 #   }
 #   ```
-log_bucket_accessibility_payload(edata) = x {
+log_bucket_accessibility_payload(edata) := x {
+	log_bucket_accessibility_payload_assert(edata, "<the argument to log_bucket_accessibility_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+log_bucket_accessibility_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "acl_rules", concat("", [hint, ".", "acl_rules"])),
+		assertion.has_key(edata, "bucket_name", concat("", [hint, ".", "bucket_name"])),
+		assertion.has_key(edata, "bucket_policy_document", concat("", [hint, ".", "bucket_policy_document"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		log_bucket_accessibility_payload_assert_acl_rules(edata, "acl_rules", concat("", [hint, ".", "acl_rules"])),
+		log_bucket_accessibility_payload_assert_bucket_name(edata, "bucket_name", concat("", [hint, ".", "bucket_name"])),
+		log_bucket_accessibility_payload_assert_bucket_policy_document(edata, "bucket_policy_document", concat("", [hint, ".", "bucket_policy_document"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+log_bucket_accessibility_payload_assert_acl_rules(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [log_bucket_accessibility_payload_assert_acl_rules_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+log_bucket_accessibility_payload_assert_acl_rules_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "grantee_url", "string", hint),
+		assertion.has_typed_key(x[key], "permission", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		log_bucket_accessibility_payload_assert_acl_rules_element_grantee_url(x[key], "grantee_url", concat("", [hint, ".", "grantee_url"])),
+		log_bucket_accessibility_payload_assert_acl_rules_element_permission(x[key], "permission", concat("", [hint, ".", "permission"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+log_bucket_accessibility_payload_assert_acl_rules_element_grantee_url(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+log_bucket_accessibility_payload_assert_acl_rules_element_permission(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+log_bucket_accessibility_payload_assert_bucket_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+log_bucket_accessibility_payload_assert_bucket_policy_document(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/cloudtrail/cloudtrail_log_file_validation.gen.rego
+++ b/decision/aws/cloudtrail/cloudtrail_log_file_validation.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.cloudtrail
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure CloudTrail log file validation is enabled
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_cloudtrail_log_file_validation".
 log_file_validation(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": log_file_validation_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ log_file_validation_allowed(h) {
 #     "enabled": false,
 #   }
 #   ```
-log_file_validation_payload(edata) = x {
+log_file_validation_payload(edata) := x {
+	log_file_validation_payload_assert(edata, "<the argument to log_file_validation_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+log_file_validation_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "enabled", concat("", [hint, ".", "enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [log_file_validation_payload_assert_enabled(edata, "enabled", concat("", [hint, ".", "enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+log_file_validation_payload_assert_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/aws/config/config_recorder_status.gen.rego
+++ b/decision/aws/config/config_recorder_status.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.config
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure AWS Config is enabled in all regions
 # You can emit this decision as follows:
@@ -23,7 +27,7 @@ import data.shisho
 #     "subject": subject,
 #     "payload": shisho.decision.aws.config.recorder_status_payload({
 #       "missing_regions": ["example"],
-#       "recorders": {"name": "example", "region": "example", "recording_group": {"all_supported": false, "resource_types": ["example"], "include_global_resource_types": false}},
+#       "recorders": [{"name": "example", "region": "example", "recording_group": {"all_supported": false, "resource_types": ["example"], "include_global_resource_types": false}}],
 #     }),
 #   })
 # }
@@ -35,6 +39,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_config_recorder_status".
 recorder_status(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": recorder_status_header({
 			"allowed": d.allowed,
@@ -96,9 +101,121 @@ recorder_status_allowed(h) {
 #   ```rego
 #   {
 #     "missing_regions": ["example"],
-#     "recorders": {"name": "example", "region": "example", "recording_group": {"all_supported": false, "resource_types": ["example"], "include_global_resource_types": false}},
+#     "recorders": [{"name": "example", "region": "example", "recording_group": {"all_supported": false, "resource_types": ["example"], "include_global_resource_types": false}}],
 #   }
 #   ```
-recorder_status_payload(edata) = x {
+recorder_status_payload(edata) := x {
+	recorder_status_payload_assert(edata, "<the argument to recorder_status_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+recorder_status_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "missing_regions", concat("", [hint, ".", "missing_regions"])),
+		assertion.has_key(edata, "recorders", concat("", [hint, ".", "recorders"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		recorder_status_payload_assert_missing_regions(edata, "missing_regions", concat("", [hint, ".", "missing_regions"])),
+		recorder_status_payload_assert_recorders(edata, "recorders", concat("", [hint, ".", "recorders"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+recorder_status_payload_assert_missing_regions(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [recorder_status_payload_assert_missing_regions_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+recorder_status_payload_assert_missing_regions_element(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+recorder_status_payload_assert_recorders(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [recorder_status_payload_assert_recorders_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+recorder_status_payload_assert_recorders_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "name", "string", hint),
+		assertion.has_typed_key(x[key], "region", "string", hint),
+		assertion.has_typed_key(x[key], "recording_group", "object", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		recorder_status_payload_assert_recorders_element_name(x[key], "name", concat("", [hint, ".", "name"])),
+		recorder_status_payload_assert_recorders_element_region(x[key], "region", concat("", [hint, ".", "region"])),
+		recorder_status_payload_assert_recorders_element_recording_group(x[key], "recording_group", concat("", [hint, ".", "recording_group"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+recorder_status_payload_assert_recorders_element_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+recorder_status_payload_assert_recorders_element_recording_group(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "all_supported", "boolean", hint),
+		assertion.has_typed_key(x[key], "resource_types", "array", hint),
+		assertion.has_typed_key(x[key], "include_global_resource_types", "boolean", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		recorder_status_payload_assert_recorders_element_recording_group_all_supported(x[key], "all_supported", concat("", [hint, ".", "all_supported"])),
+		recorder_status_payload_assert_recorders_element_recording_group_resource_types(x[key], "resource_types", concat("", [hint, ".", "resource_types"])),
+		recorder_status_payload_assert_recorders_element_recording_group_include_global_resource_types(x[key], "include_global_resource_types", concat("", [hint, ".", "include_global_resource_types"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+recorder_status_payload_assert_recorders_element_recording_group_all_supported(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false
+
+recorder_status_payload_assert_recorders_element_recording_group_include_global_resource_types(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false
+
+recorder_status_payload_assert_recorders_element_recording_group_resource_types(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [recorder_status_payload_assert_recorders_element_recording_group_resource_types_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+recorder_status_payload_assert_recorders_element_recording_group_resource_types_element(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+recorder_status_payload_assert_recorders_element_region(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/ecs/ecs_container_fs_permission.gen.rego
+++ b/decision/aws/ecs/ecs_container_fs_permission.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.ecs
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure root filesystem operation by ECS containers is limited to read-only access
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_ecs_container_fs_permission".
 container_fs_permission(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": container_fs_permission_header({
 			"allowed": d.allowed,
@@ -96,6 +101,52 @@ container_fs_permission_allowed(h) {
 #     "containers": [{"container_name": "example", "is_root_fs_readonly": false}],
 #   }
 #   ```
-container_fs_permission_payload(edata) = x {
+container_fs_permission_payload(edata) := x {
+	container_fs_permission_payload_assert(edata, "<the argument to container_fs_permission_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+container_fs_permission_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "containers", concat("", [hint, ".", "containers"]))]
+	every c in key_checks { c }
+
+	value_checks := [container_fs_permission_payload_assert_containers(edata, "containers", concat("", [hint, ".", "containers"]))]
+	every c in value_checks { c }
+} else := false
+
+container_fs_permission_payload_assert_containers(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [container_fs_permission_payload_assert_containers_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+container_fs_permission_payload_assert_containers_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "container_name", "string", hint),
+		assertion.has_typed_key(x[key], "is_root_fs_readonly", "boolean", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		container_fs_permission_payload_assert_containers_element_container_name(x[key], "container_name", concat("", [hint, ".", "container_name"])),
+		container_fs_permission_payload_assert_containers_element_is_root_fs_readonly(x[key], "is_root_fs_readonly", concat("", [hint, ".", "is_root_fs_readonly"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+container_fs_permission_payload_assert_containers_element_container_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+container_fs_permission_payload_assert_containers_element_is_root_fs_readonly(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/aws/ecs/ecs_container_privilege.gen.rego
+++ b/decision/aws/ecs/ecs_container_privilege.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.ecs
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure ECS containers run as non-privileged
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_ecs_container_privilege".
 container_privilege(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": container_privilege_header({
 			"allowed": d.allowed,
@@ -96,6 +101,52 @@ container_privilege_allowed(h) {
 #     "containers": [{"container_name": "example", "privileged": false}],
 #   }
 #   ```
-container_privilege_payload(edata) = x {
+container_privilege_payload(edata) := x {
+	container_privilege_payload_assert(edata, "<the argument to container_privilege_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+container_privilege_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "containers", concat("", [hint, ".", "containers"]))]
+	every c in key_checks { c }
+
+	value_checks := [container_privilege_payload_assert_containers(edata, "containers", concat("", [hint, ".", "containers"]))]
+	every c in value_checks { c }
+} else := false
+
+container_privilege_payload_assert_containers(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [container_privilege_payload_assert_containers_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+container_privilege_payload_assert_containers_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "container_name", "string", hint),
+		assertion.has_typed_key(x[key], "privileged", "boolean", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		container_privilege_payload_assert_containers_element_container_name(x[key], "container_name", concat("", [hint, ".", "container_name"])),
+		container_privilege_payload_assert_containers_element_privileged(x[key], "privileged", concat("", [hint, ".", "privileged"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+container_privilege_payload_assert_containers_element_container_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+container_privilege_payload_assert_containers_element_privileged(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/aws/iam/iam_access_analyzers.gen.rego
+++ b/decision/aws/iam/iam_access_analyzers.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.iam
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that IAM Access analyzer is enabled for all regions
 # You can emit this decision as follows:
@@ -35,6 +39,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_iam_access_analyzers".
 access_analyzers(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": access_analyzers_header({
 			"allowed": d.allowed,
@@ -99,6 +104,75 @@ access_analyzers_allowed(h) {
 #     "missing_regions": ["example"],
 #   }
 #   ```
-access_analyzers_payload(edata) = x {
+access_analyzers_payload(edata) := x {
+	access_analyzers_payload_assert(edata, "<the argument to access_analyzers_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+access_analyzers_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "analyzers", concat("", [hint, ".", "analyzers"])),
+		assertion.has_key(edata, "missing_regions", concat("", [hint, ".", "missing_regions"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		access_analyzers_payload_assert_analyzers(edata, "analyzers", concat("", [hint, ".", "analyzers"])),
+		access_analyzers_payload_assert_missing_regions(edata, "missing_regions", concat("", [hint, ".", "missing_regions"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+access_analyzers_payload_assert_analyzers(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [access_analyzers_payload_assert_analyzers_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+access_analyzers_payload_assert_analyzers_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "region", "string", hint),
+		assertion.has_typed_key(x[key], "analyzer_name", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		access_analyzers_payload_assert_analyzers_element_region(x[key], "region", concat("", [hint, ".", "region"])),
+		access_analyzers_payload_assert_analyzers_element_analyzer_name(x[key], "analyzer_name", concat("", [hint, ".", "analyzer_name"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+access_analyzers_payload_assert_analyzers_element_analyzer_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+access_analyzers_payload_assert_analyzers_element_region(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+access_analyzers_payload_assert_missing_regions(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [access_analyzers_payload_assert_missing_regions_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+access_analyzers_payload_assert_missing_regions_element(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/iam/iam_account_alternate_contact.gen.rego
+++ b/decision/aws/iam/iam_account_alternate_contact.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.iam
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that security contact information is registered to AWS accounts
 # You can emit this decision as follows:
@@ -36,6 +40,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_iam_account_alternate_contact".
 account_alternate_contact(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": account_alternate_contact_header({
 			"allowed": d.allowed,
@@ -102,6 +107,37 @@ account_alternate_contact_allowed(h) {
 #     "contact_for_security_registered": false,
 #   }
 #   ```
-account_alternate_contact_payload(edata) = x {
+account_alternate_contact_payload(edata) := x {
+	account_alternate_contact_payload_assert(edata, "<the argument to account_alternate_contact_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+account_alternate_contact_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "contact_for_billing_registered", concat("", [hint, ".", "contact_for_billing_registered"])),
+		assertion.has_key(edata, "contact_for_operations_registered", concat("", [hint, ".", "contact_for_operations_registered"])),
+		assertion.has_key(edata, "contact_for_security_registered", concat("", [hint, ".", "contact_for_security_registered"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		account_alternate_contact_payload_assert_contact_for_billing_registered(edata, "contact_for_billing_registered", concat("", [hint, ".", "contact_for_billing_registered"])),
+		account_alternate_contact_payload_assert_contact_for_operations_registered(edata, "contact_for_operations_registered", concat("", [hint, ".", "contact_for_operations_registered"])),
+		account_alternate_contact_payload_assert_contact_for_security_registered(edata, "contact_for_security_registered", concat("", [hint, ".", "contact_for_security_registered"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+account_alternate_contact_payload_assert_contact_for_billing_registered(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false
+
+account_alternate_contact_payload_assert_contact_for_operations_registered(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false
+
+account_alternate_contact_payload_assert_contact_for_security_registered(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/aws/iam/iam_administrative_policy_limitation.gen.rego
+++ b/decision/aws/iam/iam_administrative_policy_limitation.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.iam
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure IAM policies that allow full administrative privileges are not attached
 # You can emit this decision as follows:
@@ -33,6 +37,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_iam_administrative_policy_limitation".
 administrative_policy_limitation(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": administrative_policy_limitation_header({
 			"allowed": d.allowed,
@@ -88,6 +93,17 @@ administrative_policy_limitation_allowed(h) {
 #   Emits a decision entry describing the detail of a decision decision.api.shisho.dev/v1beta:aws_iam_administrative_policy_limitation
 #
 #   The parameter `data` shoud be empty object (`{}`).
-administrative_policy_limitation_payload(edata) = x {
+administrative_policy_limitation_payload(edata) := x {
+	administrative_policy_limitation_payload_assert(edata, "<the argument to administrative_policy_limitation_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+administrative_policy_limitation_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := []
+	every c in key_checks { c }
+
+	value_checks := []
+	every c in value_checks { c }
+} else := false

--- a/decision/aws/iam/iam_console_user_keys.gen.rego
+++ b/decision/aws/iam/iam_console_user_keys.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.iam
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure access keys during initial user setup for all IAM users with a console password
 # You can emit this decision as follows:
@@ -37,6 +41,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_iam_console_user_keys".
 console_user_keys(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": console_user_keys_header({
 			"allowed": d.allowed,
@@ -105,6 +110,43 @@ console_user_keys_allowed(h) {
 #     "has_unused_console_password": false,
 #   }
 #   ```
-console_user_keys_payload(edata) = x {
+console_user_keys_payload(edata) := x {
+	console_user_keys_payload_assert(edata, "<the argument to console_user_keys_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+console_user_keys_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "has_access_key", concat("", [hint, ".", "has_access_key"])),
+		assertion.has_key(edata, "has_console_password", concat("", [hint, ".", "has_console_password"])),
+		assertion.has_key(edata, "has_unused_access_key", concat("", [hint, ".", "has_unused_access_key"])),
+		assertion.has_key(edata, "has_unused_console_password", concat("", [hint, ".", "has_unused_console_password"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		console_user_keys_payload_assert_has_access_key(edata, "has_access_key", concat("", [hint, ".", "has_access_key"])),
+		console_user_keys_payload_assert_has_console_password(edata, "has_console_password", concat("", [hint, ".", "has_console_password"])),
+		console_user_keys_payload_assert_has_unused_access_key(edata, "has_unused_access_key", concat("", [hint, ".", "has_unused_access_key"])),
+		console_user_keys_payload_assert_has_unused_console_password(edata, "has_unused_console_password", concat("", [hint, ".", "has_unused_console_password"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+console_user_keys_payload_assert_has_access_key(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false
+
+console_user_keys_payload_assert_has_console_password(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false
+
+console_user_keys_payload_assert_has_unused_access_key(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false
+
+console_user_keys_payload_assert_has_unused_console_password(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/aws/iam/iam_root_user_hardware_mfa.gen.rego
+++ b/decision/aws/iam/iam_root_user_hardware_mfa.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.iam
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure Hardware MFA is enabled for the root user account
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_iam_root_user_hardware_mfa".
 root_user_hardware_mfa(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": root_user_hardware_mfa_header({
 			"allowed": d.allowed,
@@ -97,6 +102,21 @@ root_user_hardware_mfa_allowed(h) {
 #     "hardware_mfa_enabled": false,
 #   }
 #   ```
-root_user_hardware_mfa_payload(edata) = x {
+root_user_hardware_mfa_payload(edata) := x {
+	root_user_hardware_mfa_payload_assert(edata, "<the argument to root_user_hardware_mfa_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+root_user_hardware_mfa_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "hardware_mfa_enabled", concat("", [hint, ".", "hardware_mfa_enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [root_user_hardware_mfa_payload_assert_hardware_mfa_enabled(edata, "hardware_mfa_enabled", concat("", [hint, ".", "hardware_mfa_enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+root_user_hardware_mfa_payload_assert_hardware_mfa_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/aws/iam/iam_root_user_mfa.gen.rego
+++ b/decision/aws/iam/iam_root_user_mfa.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.iam
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure MFA is enabled for the root user account
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_iam_root_user_mfa".
 root_user_mfa(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": root_user_mfa_header({
 			"allowed": d.allowed,
@@ -97,6 +102,21 @@ root_user_mfa_allowed(h) {
 #     "mfa_enabled": false,
 #   }
 #   ```
-root_user_mfa_payload(edata) = x {
+root_user_mfa_payload(edata) := x {
+	root_user_mfa_payload_assert(edata, "<the argument to root_user_mfa_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+root_user_mfa_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "mfa_enabled", concat("", [hint, ".", "mfa_enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [root_user_mfa_payload_assert_mfa_enabled(edata, "mfa_enabled", concat("", [hint, ".", "mfa_enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+root_user_mfa_payload_assert_mfa_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/aws/iam/iam_user_group_permission_assignment.gen.rego
+++ b/decision/aws/iam/iam_user_group_permission_assignment.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.iam
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure IAM users receive permissions only through groups
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_iam_user_group_permission_assignment".
 user_group_permission_assignment(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": user_group_permission_assignment_header({
 			"allowed": d.allowed,
@@ -97,6 +102,34 @@ user_group_permission_assignment_allowed(h) {
 #     "attached_policy_names": ["example"],
 #   }
 #   ```
-user_group_permission_assignment_payload(edata) = x {
+user_group_permission_assignment_payload(edata) := x {
+	user_group_permission_assignment_payload_assert(edata, "<the argument to user_group_permission_assignment_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+user_group_permission_assignment_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "attached_policy_names", concat("", [hint, ".", "attached_policy_names"]))]
+	every c in key_checks { c }
+
+	value_checks := [user_group_permission_assignment_payload_assert_attached_policy_names(edata, "attached_policy_names", concat("", [hint, ".", "attached_policy_names"]))]
+	every c in value_checks { c }
+} else := false
+
+user_group_permission_assignment_payload_assert_attached_policy_names(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [user_group_permission_assignment_payload_assert_attached_policy_names_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+user_group_permission_assignment_payload_assert_attached_policy_names_element(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/kms/kms_symmetric_cmk_rotation.gen.rego
+++ b/decision/aws/kms/kms_symmetric_cmk_rotation.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.kms
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure rotation for customer created symmetric CMKs is enabled
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_kms_symmetric_cmk_rotation".
 symmetric_cmk_rotation(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": symmetric_cmk_rotation_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ symmetric_cmk_rotation_allowed(h) {
 #     "enabled": false,
 #   }
 #   ```
-symmetric_cmk_rotation_payload(edata) = x {
+symmetric_cmk_rotation_payload(edata) := x {
+	symmetric_cmk_rotation_payload_assert(edata, "<the argument to symmetric_cmk_rotation_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+symmetric_cmk_rotation_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "enabled", concat("", [hint, ".", "enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [symmetric_cmk_rotation_payload_assert_enabled(edata, "enabled", concat("", [hint, ".", "enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+symmetric_cmk_rotation_payload_assert_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/aws/logmetric/logmetric_bucket_policy_changes.gen.rego
+++ b/decision/aws/logmetric/logmetric_bucket_policy_changes.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure a log metric filter and alarm exist for S3 bucket policy changes
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_logmetric_bucket_policy_changes".
 bucket_policy_changes(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": bucket_policy_changes_header({
 			"allowed": d.allowed,
@@ -96,6 +101,65 @@ bucket_policy_changes_allowed(h) {
 #     "cis_notification_implementations": [{"trail_name": "example", "metric_name": "example", "alarm_name": "example", "sns_topic_arn": "example"}],
 #   }
 #   ```
-bucket_policy_changes_payload(edata) = x {
+bucket_policy_changes_payload(edata) := x {
+	bucket_policy_changes_payload_assert(edata, "<the argument to bucket_policy_changes_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+bucket_policy_changes_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [bucket_policy_changes_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+bucket_policy_changes_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [bucket_policy_changes_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+bucket_policy_changes_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "trail_name", "string", hint),
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "sns_topic_arn", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		bucket_policy_changes_payload_assert_cis_notification_implementations_element_trail_name(x[key], "trail_name", concat("", [hint, ".", "trail_name"])),
+		bucket_policy_changes_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		bucket_policy_changes_payload_assert_cis_notification_implementations_element_alarm_name(x[key], "alarm_name", concat("", [hint, ".", "alarm_name"])),
+		bucket_policy_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x[key], "sns_topic_arn", concat("", [hint, ".", "sns_topic_arn"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+bucket_policy_changes_payload_assert_cis_notification_implementations_element_alarm_name(x, key, hint) {
+	not primitive.has_key(x, key)
+} else {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+bucket_policy_changes_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+bucket_policy_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+bucket_policy_changes_payload_assert_cis_notification_implementations_element_trail_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/logmetric/logmetric_cloudtrail_changes.gen.rego
+++ b/decision/aws/logmetric/logmetric_cloudtrail_changes.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure a log metric filter and alarm exist for CloudTrail configuration changes
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_logmetric_cloudtrail_changes".
 cloudtrail_changes(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": cloudtrail_changes_header({
 			"allowed": d.allowed,
@@ -96,6 +101,65 @@ cloudtrail_changes_allowed(h) {
 #     "cis_notification_implementations": [{"trail_name": "example", "metric_name": "example", "alarm_name": "example", "sns_topic_arn": "example"}],
 #   }
 #   ```
-cloudtrail_changes_payload(edata) = x {
+cloudtrail_changes_payload(edata) := x {
+	cloudtrail_changes_payload_assert(edata, "<the argument to cloudtrail_changes_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+cloudtrail_changes_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [cloudtrail_changes_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+cloudtrail_changes_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [cloudtrail_changes_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+cloudtrail_changes_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "trail_name", "string", hint),
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "sns_topic_arn", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		cloudtrail_changes_payload_assert_cis_notification_implementations_element_trail_name(x[key], "trail_name", concat("", [hint, ".", "trail_name"])),
+		cloudtrail_changes_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		cloudtrail_changes_payload_assert_cis_notification_implementations_element_alarm_name(x[key], "alarm_name", concat("", [hint, ".", "alarm_name"])),
+		cloudtrail_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x[key], "sns_topic_arn", concat("", [hint, ".", "sns_topic_arn"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+cloudtrail_changes_payload_assert_cis_notification_implementations_element_alarm_name(x, key, hint) {
+	not primitive.has_key(x, key)
+} else {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+cloudtrail_changes_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+cloudtrail_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+cloudtrail_changes_payload_assert_cis_notification_implementations_element_trail_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/logmetric/logmetric_cmk_changes.gen.rego
+++ b/decision/aws/logmetric/logmetric_cmk_changes.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure a log metric filter and alarm exist for disabling or scheduled deletion of customer created CMKs
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_logmetric_cmk_changes".
 cmk_changes(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": cmk_changes_header({
 			"allowed": d.allowed,
@@ -96,6 +101,65 @@ cmk_changes_allowed(h) {
 #     "cis_notification_implementations": [{"trail_name": "example", "metric_name": "example", "alarm_name": "example", "sns_topic_arn": "example"}],
 #   }
 #   ```
-cmk_changes_payload(edata) = x {
+cmk_changes_payload(edata) := x {
+	cmk_changes_payload_assert(edata, "<the argument to cmk_changes_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+cmk_changes_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [cmk_changes_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+cmk_changes_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [cmk_changes_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+cmk_changes_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "trail_name", "string", hint),
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "sns_topic_arn", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		cmk_changes_payload_assert_cis_notification_implementations_element_trail_name(x[key], "trail_name", concat("", [hint, ".", "trail_name"])),
+		cmk_changes_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		cmk_changes_payload_assert_cis_notification_implementations_element_alarm_name(x[key], "alarm_name", concat("", [hint, ".", "alarm_name"])),
+		cmk_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x[key], "sns_topic_arn", concat("", [hint, ".", "sns_topic_arn"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+cmk_changes_payload_assert_cis_notification_implementations_element_alarm_name(x, key, hint) {
+	not primitive.has_key(x, key)
+} else {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+cmk_changes_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+cmk_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+cmk_changes_payload_assert_cis_notification_implementations_element_trail_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/logmetric/logmetric_config_changes.gen.rego
+++ b/decision/aws/logmetric/logmetric_config_changes.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure a log metric filter and alarm exist for AWS Config configuration changes
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_logmetric_config_changes".
 config_changes(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": config_changes_header({
 			"allowed": d.allowed,
@@ -96,6 +101,65 @@ config_changes_allowed(h) {
 #     "cis_notification_implementations": [{"trail_name": "example", "metric_name": "example", "alarm_name": "example", "sns_topic_arn": "example"}],
 #   }
 #   ```
-config_changes_payload(edata) = x {
+config_changes_payload(edata) := x {
+	config_changes_payload_assert(edata, "<the argument to config_changes_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+config_changes_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [config_changes_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+config_changes_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [config_changes_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+config_changes_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "trail_name", "string", hint),
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "sns_topic_arn", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		config_changes_payload_assert_cis_notification_implementations_element_trail_name(x[key], "trail_name", concat("", [hint, ".", "trail_name"])),
+		config_changes_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		config_changes_payload_assert_cis_notification_implementations_element_alarm_name(x[key], "alarm_name", concat("", [hint, ".", "alarm_name"])),
+		config_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x[key], "sns_topic_arn", concat("", [hint, ".", "sns_topic_arn"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+config_changes_payload_assert_cis_notification_implementations_element_alarm_name(x, key, hint) {
+	not primitive.has_key(x, key)
+} else {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+config_changes_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+config_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+config_changes_payload_assert_cis_notification_implementations_element_trail_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/logmetric/logmetric_console_auth_failure.gen.rego
+++ b/decision/aws/logmetric/logmetric_console_auth_failure.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure a log metric filter and alarm exist for AWS Management Console authentication failures
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_logmetric_console_auth_failure".
 console_auth_failure(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": console_auth_failure_header({
 			"allowed": d.allowed,
@@ -96,6 +101,65 @@ console_auth_failure_allowed(h) {
 #     "cis_notification_implementations": [{"trail_name": "example", "metric_name": "example", "alarm_name": "example", "sns_topic_arn": "example"}],
 #   }
 #   ```
-console_auth_failure_payload(edata) = x {
+console_auth_failure_payload(edata) := x {
+	console_auth_failure_payload_assert(edata, "<the argument to console_auth_failure_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+console_auth_failure_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [console_auth_failure_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+console_auth_failure_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [console_auth_failure_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+console_auth_failure_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "trail_name", "string", hint),
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "sns_topic_arn", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		console_auth_failure_payload_assert_cis_notification_implementations_element_trail_name(x[key], "trail_name", concat("", [hint, ".", "trail_name"])),
+		console_auth_failure_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		console_auth_failure_payload_assert_cis_notification_implementations_element_alarm_name(x[key], "alarm_name", concat("", [hint, ".", "alarm_name"])),
+		console_auth_failure_payload_assert_cis_notification_implementations_element_sns_topic_arn(x[key], "sns_topic_arn", concat("", [hint, ".", "sns_topic_arn"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+console_auth_failure_payload_assert_cis_notification_implementations_element_alarm_name(x, key, hint) {
+	not primitive.has_key(x, key)
+} else {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+console_auth_failure_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+console_auth_failure_payload_assert_cis_notification_implementations_element_sns_topic_arn(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+console_auth_failure_payload_assert_cis_notification_implementations_element_trail_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/logmetric/logmetric_console_root_user_usage.gen.rego
+++ b/decision/aws/logmetric/logmetric_console_root_user_usage.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure a log metric filter and alarm exist for usage of the root user
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_logmetric_console_root_user_usage".
 console_root_user_usage(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": console_root_user_usage_header({
 			"allowed": d.allowed,
@@ -96,6 +101,65 @@ console_root_user_usage_allowed(h) {
 #     "cis_notification_implementations": [{"trail_name": "example", "metric_name": "example", "alarm_name": "example", "sns_topic_arn": "example"}],
 #   }
 #   ```
-console_root_user_usage_payload(edata) = x {
+console_root_user_usage_payload(edata) := x {
+	console_root_user_usage_payload_assert(edata, "<the argument to console_root_user_usage_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+console_root_user_usage_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [console_root_user_usage_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+console_root_user_usage_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [console_root_user_usage_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+console_root_user_usage_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "trail_name", "string", hint),
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "sns_topic_arn", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		console_root_user_usage_payload_assert_cis_notification_implementations_element_trail_name(x[key], "trail_name", concat("", [hint, ".", "trail_name"])),
+		console_root_user_usage_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		console_root_user_usage_payload_assert_cis_notification_implementations_element_alarm_name(x[key], "alarm_name", concat("", [hint, ".", "alarm_name"])),
+		console_root_user_usage_payload_assert_cis_notification_implementations_element_sns_topic_arn(x[key], "sns_topic_arn", concat("", [hint, ".", "sns_topic_arn"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+console_root_user_usage_payload_assert_cis_notification_implementations_element_alarm_name(x, key, hint) {
+	not primitive.has_key(x, key)
+} else {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+console_root_user_usage_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+console_root_user_usage_payload_assert_cis_notification_implementations_element_sns_topic_arn(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+console_root_user_usage_payload_assert_cis_notification_implementations_element_trail_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/logmetric/logmetric_console_signin_mfa.gen.rego
+++ b/decision/aws/logmetric/logmetric_console_signin_mfa.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure a log metric filter and alarm exist for Management Console sign-in without MFA
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_logmetric_console_signin_mfa".
 console_signin_mfa(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": console_signin_mfa_header({
 			"allowed": d.allowed,
@@ -96,6 +101,65 @@ console_signin_mfa_allowed(h) {
 #     "cis_notification_implementations": [{"trail_name": "example", "metric_name": "example", "alarm_name": "example", "sns_topic_arn": "example"}],
 #   }
 #   ```
-console_signin_mfa_payload(edata) = x {
+console_signin_mfa_payload(edata) := x {
+	console_signin_mfa_payload_assert(edata, "<the argument to console_signin_mfa_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+console_signin_mfa_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [console_signin_mfa_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+console_signin_mfa_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [console_signin_mfa_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+console_signin_mfa_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "trail_name", "string", hint),
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "sns_topic_arn", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		console_signin_mfa_payload_assert_cis_notification_implementations_element_trail_name(x[key], "trail_name", concat("", [hint, ".", "trail_name"])),
+		console_signin_mfa_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		console_signin_mfa_payload_assert_cis_notification_implementations_element_alarm_name(x[key], "alarm_name", concat("", [hint, ".", "alarm_name"])),
+		console_signin_mfa_payload_assert_cis_notification_implementations_element_sns_topic_arn(x[key], "sns_topic_arn", concat("", [hint, ".", "sns_topic_arn"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+console_signin_mfa_payload_assert_cis_notification_implementations_element_alarm_name(x, key, hint) {
+	not primitive.has_key(x, key)
+} else {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+console_signin_mfa_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+console_signin_mfa_payload_assert_cis_notification_implementations_element_sns_topic_arn(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+console_signin_mfa_payload_assert_cis_notification_implementations_element_trail_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/logmetric/logmetric_iam_policy_changes.gen.rego
+++ b/decision/aws/logmetric/logmetric_iam_policy_changes.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure a log metric filter and alarm exist for IAM policy changes
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_logmetric_iam_policy_changes".
 iam_policy_changes(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": iam_policy_changes_header({
 			"allowed": d.allowed,
@@ -96,6 +101,65 @@ iam_policy_changes_allowed(h) {
 #     "cis_notification_implementations": [{"trail_name": "example", "metric_name": "example", "alarm_name": "example", "sns_topic_arn": "example"}],
 #   }
 #   ```
-iam_policy_changes_payload(edata) = x {
+iam_policy_changes_payload(edata) := x {
+	iam_policy_changes_payload_assert(edata, "<the argument to iam_policy_changes_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+iam_policy_changes_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [iam_policy_changes_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+iam_policy_changes_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [iam_policy_changes_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+iam_policy_changes_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "trail_name", "string", hint),
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "sns_topic_arn", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		iam_policy_changes_payload_assert_cis_notification_implementations_element_trail_name(x[key], "trail_name", concat("", [hint, ".", "trail_name"])),
+		iam_policy_changes_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		iam_policy_changes_payload_assert_cis_notification_implementations_element_alarm_name(x[key], "alarm_name", concat("", [hint, ".", "alarm_name"])),
+		iam_policy_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x[key], "sns_topic_arn", concat("", [hint, ".", "sns_topic_arn"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+iam_policy_changes_payload_assert_cis_notification_implementations_element_alarm_name(x, key, hint) {
+	not primitive.has_key(x, key)
+} else {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+iam_policy_changes_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+iam_policy_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+iam_policy_changes_payload_assert_cis_notification_implementations_element_trail_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/logmetric/logmetric_nacl_changes.gen.rego
+++ b/decision/aws/logmetric/logmetric_nacl_changes.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure a log metric filter and alarm exist for changes to Network Access Control Lists (NACL)
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_logmetric_nacl_changes".
 nacl_changes(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": nacl_changes_header({
 			"allowed": d.allowed,
@@ -96,6 +101,65 @@ nacl_changes_allowed(h) {
 #     "cis_notification_implementations": [{"trail_name": "example", "metric_name": "example", "alarm_name": "example", "sns_topic_arn": "example"}],
 #   }
 #   ```
-nacl_changes_payload(edata) = x {
+nacl_changes_payload(edata) := x {
+	nacl_changes_payload_assert(edata, "<the argument to nacl_changes_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+nacl_changes_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [nacl_changes_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+nacl_changes_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [nacl_changes_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+nacl_changes_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "trail_name", "string", hint),
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "sns_topic_arn", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		nacl_changes_payload_assert_cis_notification_implementations_element_trail_name(x[key], "trail_name", concat("", [hint, ".", "trail_name"])),
+		nacl_changes_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		nacl_changes_payload_assert_cis_notification_implementations_element_alarm_name(x[key], "alarm_name", concat("", [hint, ".", "alarm_name"])),
+		nacl_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x[key], "sns_topic_arn", concat("", [hint, ".", "sns_topic_arn"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+nacl_changes_payload_assert_cis_notification_implementations_element_alarm_name(x, key, hint) {
+	not primitive.has_key(x, key)
+} else {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+nacl_changes_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+nacl_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+nacl_changes_payload_assert_cis_notification_implementations_element_trail_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/logmetric/logmetric_network_gateway_changes.gen.rego
+++ b/decision/aws/logmetric/logmetric_network_gateway_changes.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure a log metric filter and alarm exist for changes to network gateways
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_logmetric_network_gateway_changes".
 network_gateway_changes(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": network_gateway_changes_header({
 			"allowed": d.allowed,
@@ -96,6 +101,65 @@ network_gateway_changes_allowed(h) {
 #     "cis_notification_implementations": [{"trail_name": "example", "metric_name": "example", "alarm_name": "example", "sns_topic_arn": "example"}],
 #   }
 #   ```
-network_gateway_changes_payload(edata) = x {
+network_gateway_changes_payload(edata) := x {
+	network_gateway_changes_payload_assert(edata, "<the argument to network_gateway_changes_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+network_gateway_changes_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [network_gateway_changes_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+network_gateway_changes_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [network_gateway_changes_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+network_gateway_changes_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "trail_name", "string", hint),
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "sns_topic_arn", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		network_gateway_changes_payload_assert_cis_notification_implementations_element_trail_name(x[key], "trail_name", concat("", [hint, ".", "trail_name"])),
+		network_gateway_changes_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		network_gateway_changes_payload_assert_cis_notification_implementations_element_alarm_name(x[key], "alarm_name", concat("", [hint, ".", "alarm_name"])),
+		network_gateway_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x[key], "sns_topic_arn", concat("", [hint, ".", "sns_topic_arn"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+network_gateway_changes_payload_assert_cis_notification_implementations_element_alarm_name(x, key, hint) {
+	not primitive.has_key(x, key)
+} else {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+network_gateway_changes_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+network_gateway_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+network_gateway_changes_payload_assert_cis_notification_implementations_element_trail_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/logmetric/logmetric_organizations_changes.gen.rego
+++ b/decision/aws/logmetric/logmetric_organizations_changes.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure a log metric filter and alarm exist for AWS Organizations changes
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_logmetric_organizations_changes".
 organizations_changes(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": organizations_changes_header({
 			"allowed": d.allowed,
@@ -96,6 +101,65 @@ organizations_changes_allowed(h) {
 #     "cis_notification_implementations": [{"trail_name": "example", "metric_name": "example", "alarm_name": "example", "sns_topic_arn": "example"}],
 #   }
 #   ```
-organizations_changes_payload(edata) = x {
+organizations_changes_payload(edata) := x {
+	organizations_changes_payload_assert(edata, "<the argument to organizations_changes_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+organizations_changes_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [organizations_changes_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+organizations_changes_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [organizations_changes_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+organizations_changes_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "trail_name", "string", hint),
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "sns_topic_arn", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		organizations_changes_payload_assert_cis_notification_implementations_element_trail_name(x[key], "trail_name", concat("", [hint, ".", "trail_name"])),
+		organizations_changes_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		organizations_changes_payload_assert_cis_notification_implementations_element_alarm_name(x[key], "alarm_name", concat("", [hint, ".", "alarm_name"])),
+		organizations_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x[key], "sns_topic_arn", concat("", [hint, ".", "sns_topic_arn"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+organizations_changes_payload_assert_cis_notification_implementations_element_alarm_name(x, key, hint) {
+	not primitive.has_key(x, key)
+} else {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+organizations_changes_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+organizations_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+organizations_changes_payload_assert_cis_notification_implementations_element_trail_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/logmetric/logmetric_route_table_changes.gen.rego
+++ b/decision/aws/logmetric/logmetric_route_table_changes.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure a log metric filter and alarm exist for route table changes
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_logmetric_route_table_changes".
 route_table_changes(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": route_table_changes_header({
 			"allowed": d.allowed,
@@ -96,6 +101,65 @@ route_table_changes_allowed(h) {
 #     "cis_notification_implementations": [{"trail_name": "example", "metric_name": "example", "alarm_name": "example", "sns_topic_arn": "example"}],
 #   }
 #   ```
-route_table_changes_payload(edata) = x {
+route_table_changes_payload(edata) := x {
+	route_table_changes_payload_assert(edata, "<the argument to route_table_changes_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+route_table_changes_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [route_table_changes_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+route_table_changes_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [route_table_changes_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+route_table_changes_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "trail_name", "string", hint),
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "sns_topic_arn", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		route_table_changes_payload_assert_cis_notification_implementations_element_trail_name(x[key], "trail_name", concat("", [hint, ".", "trail_name"])),
+		route_table_changes_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		route_table_changes_payload_assert_cis_notification_implementations_element_alarm_name(x[key], "alarm_name", concat("", [hint, ".", "alarm_name"])),
+		route_table_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x[key], "sns_topic_arn", concat("", [hint, ".", "sns_topic_arn"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+route_table_changes_payload_assert_cis_notification_implementations_element_alarm_name(x, key, hint) {
+	not primitive.has_key(x, key)
+} else {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+route_table_changes_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+route_table_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+route_table_changes_payload_assert_cis_notification_implementations_element_trail_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/logmetric/logmetric_security_group_changes.gen.rego
+++ b/decision/aws/logmetric/logmetric_security_group_changes.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure a log metric filter and alarm exist for security group changes
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_logmetric_security_group_changes".
 security_group_changes(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": security_group_changes_header({
 			"allowed": d.allowed,
@@ -96,6 +101,65 @@ security_group_changes_allowed(h) {
 #     "cis_notification_implementations": [{"trail_name": "example", "metric_name": "example", "alarm_name": "example", "sns_topic_arn": "example"}],
 #   }
 #   ```
-security_group_changes_payload(edata) = x {
+security_group_changes_payload(edata) := x {
+	security_group_changes_payload_assert(edata, "<the argument to security_group_changes_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+security_group_changes_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [security_group_changes_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+security_group_changes_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [security_group_changes_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+security_group_changes_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "trail_name", "string", hint),
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "sns_topic_arn", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		security_group_changes_payload_assert_cis_notification_implementations_element_trail_name(x[key], "trail_name", concat("", [hint, ".", "trail_name"])),
+		security_group_changes_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		security_group_changes_payload_assert_cis_notification_implementations_element_alarm_name(x[key], "alarm_name", concat("", [hint, ".", "alarm_name"])),
+		security_group_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x[key], "sns_topic_arn", concat("", [hint, ".", "sns_topic_arn"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+security_group_changes_payload_assert_cis_notification_implementations_element_alarm_name(x, key, hint) {
+	not primitive.has_key(x, key)
+} else {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+security_group_changes_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+security_group_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+security_group_changes_payload_assert_cis_notification_implementations_element_trail_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/logmetric/logmetric_unauthorized_api_calls.gen.rego
+++ b/decision/aws/logmetric/logmetric_unauthorized_api_calls.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure a log metric filter and alarm exist for unauthorized API calls
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_logmetric_unauthorized_api_calls".
 unauthorized_api_calls(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": unauthorized_api_calls_header({
 			"allowed": d.allowed,
@@ -96,6 +101,65 @@ unauthorized_api_calls_allowed(h) {
 #     "cis_notification_implementations": [{"trail_name": "example", "metric_name": "example", "alarm_name": "example", "sns_topic_arn": "example"}],
 #   }
 #   ```
-unauthorized_api_calls_payload(edata) = x {
+unauthorized_api_calls_payload(edata) := x {
+	unauthorized_api_calls_payload_assert(edata, "<the argument to unauthorized_api_calls_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+unauthorized_api_calls_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [unauthorized_api_calls_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+unauthorized_api_calls_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [unauthorized_api_calls_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+unauthorized_api_calls_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "trail_name", "string", hint),
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "sns_topic_arn", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		unauthorized_api_calls_payload_assert_cis_notification_implementations_element_trail_name(x[key], "trail_name", concat("", [hint, ".", "trail_name"])),
+		unauthorized_api_calls_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		unauthorized_api_calls_payload_assert_cis_notification_implementations_element_alarm_name(x[key], "alarm_name", concat("", [hint, ".", "alarm_name"])),
+		unauthorized_api_calls_payload_assert_cis_notification_implementations_element_sns_topic_arn(x[key], "sns_topic_arn", concat("", [hint, ".", "sns_topic_arn"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+unauthorized_api_calls_payload_assert_cis_notification_implementations_element_alarm_name(x, key, hint) {
+	not primitive.has_key(x, key)
+} else {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+unauthorized_api_calls_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+unauthorized_api_calls_payload_assert_cis_notification_implementations_element_sns_topic_arn(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+unauthorized_api_calls_payload_assert_cis_notification_implementations_element_trail_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/logmetric/logmetric_vpc_changes.gen.rego
+++ b/decision/aws/logmetric/logmetric_vpc_changes.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure a log metric filter and alarm exist for VPC changes
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_logmetric_vpc_changes".
 vpc_changes(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": vpc_changes_header({
 			"allowed": d.allowed,
@@ -96,6 +101,65 @@ vpc_changes_allowed(h) {
 #     "cis_notification_implementations": [{"trail_name": "example", "metric_name": "example", "alarm_name": "example", "sns_topic_arn": "example"}],
 #   }
 #   ```
-vpc_changes_payload(edata) = x {
+vpc_changes_payload(edata) := x {
+	vpc_changes_payload_assert(edata, "<the argument to vpc_changes_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+vpc_changes_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [vpc_changes_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+vpc_changes_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [vpc_changes_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+vpc_changes_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "trail_name", "string", hint),
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "sns_topic_arn", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		vpc_changes_payload_assert_cis_notification_implementations_element_trail_name(x[key], "trail_name", concat("", [hint, ".", "trail_name"])),
+		vpc_changes_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		vpc_changes_payload_assert_cis_notification_implementations_element_alarm_name(x[key], "alarm_name", concat("", [hint, ".", "alarm_name"])),
+		vpc_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x[key], "sns_topic_arn", concat("", [hint, ".", "sns_topic_arn"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+vpc_changes_payload_assert_cis_notification_implementations_element_alarm_name(x, key, hint) {
+	not primitive.has_key(x, key)
+} else {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+vpc_changes_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+vpc_changes_payload_assert_cis_notification_implementations_element_sns_topic_arn(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+vpc_changes_payload_assert_cis_notification_implementations_element_trail_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/aws/networking/networking_sg_baseline.gen.rego
+++ b/decision/aws/networking/networking_sg_baseline.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.networking
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure the default security group restricts all traffic
 # You can emit this decision as follows:
@@ -35,6 +39,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_networking_sg_baseline".
 sg_baseline(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": sg_baseline_header({
 			"allowed": d.allowed,
@@ -99,6 +104,105 @@ sg_baseline_allowed(h) {
 #     "ip_permissions_ingress": [{"ip_protocol": "example", "from_port": 0, "to_port": 0}],
 #   }
 #   ```
-sg_baseline_payload(edata) = x {
+sg_baseline_payload(edata) := x {
+	sg_baseline_payload_assert(edata, "<the argument to sg_baseline_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+sg_baseline_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "ip_permissions_egress", concat("", [hint, ".", "ip_permissions_egress"])),
+		assertion.has_key(edata, "ip_permissions_ingress", concat("", [hint, ".", "ip_permissions_ingress"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		sg_baseline_payload_assert_ip_permissions_egress(edata, "ip_permissions_egress", concat("", [hint, ".", "ip_permissions_egress"])),
+		sg_baseline_payload_assert_ip_permissions_ingress(edata, "ip_permissions_ingress", concat("", [hint, ".", "ip_permissions_ingress"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+sg_baseline_payload_assert_ip_permissions_egress(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [sg_baseline_payload_assert_ip_permissions_egress_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+sg_baseline_payload_assert_ip_permissions_egress_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "ip_protocol", "string", hint),
+		assertion.has_typed_key(x[key], "from_port", "number", hint),
+		assertion.has_typed_key(x[key], "to_port", "number", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		sg_baseline_payload_assert_ip_permissions_egress_element_ip_protocol(x[key], "ip_protocol", concat("", [hint, ".", "ip_protocol"])),
+		sg_baseline_payload_assert_ip_permissions_egress_element_from_port(x[key], "from_port", concat("", [hint, ".", "from_port"])),
+		sg_baseline_payload_assert_ip_permissions_egress_element_to_port(x[key], "to_port", concat("", [hint, ".", "to_port"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+sg_baseline_payload_assert_ip_permissions_egress_element_from_port(x, key, hint) {
+	assertion.is_type(x[key], "number", hint)
+} else := false
+
+sg_baseline_payload_assert_ip_permissions_egress_element_ip_protocol(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+sg_baseline_payload_assert_ip_permissions_egress_element_to_port(x, key, hint) {
+	assertion.is_type(x[key], "number", hint)
+} else := false
+
+sg_baseline_payload_assert_ip_permissions_ingress(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [sg_baseline_payload_assert_ip_permissions_ingress_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+sg_baseline_payload_assert_ip_permissions_ingress_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "ip_protocol", "string", hint),
+		assertion.has_typed_key(x[key], "from_port", "number", hint),
+		assertion.has_typed_key(x[key], "to_port", "number", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		sg_baseline_payload_assert_ip_permissions_ingress_element_ip_protocol(x[key], "ip_protocol", concat("", [hint, ".", "ip_protocol"])),
+		sg_baseline_payload_assert_ip_permissions_ingress_element_from_port(x[key], "from_port", concat("", [hint, ".", "from_port"])),
+		sg_baseline_payload_assert_ip_permissions_ingress_element_to_port(x[key], "to_port", concat("", [hint, ".", "to_port"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+sg_baseline_payload_assert_ip_permissions_ingress_element_from_port(x, key, hint) {
+	assertion.is_type(x[key], "number", hint)
+} else := false
+
+sg_baseline_payload_assert_ip_permissions_ingress_element_ip_protocol(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+sg_baseline_payload_assert_ip_permissions_ingress_element_to_port(x, key, hint) {
+	assertion.is_type(x[key], "number", hint)
+} else := false

--- a/decision/aws/networking/networking_sg_ingress_v4.gen.rego
+++ b/decision/aws/networking/networking_sg_ingress_v4.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.networking
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure no security groups allow ingress from 0.0.0.0/0 to remote server administration ports
 # You can emit this decision as follows:
@@ -33,6 +37,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_networking_sg_ingress_v4".
 sg_ingress_v4(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": sg_ingress_v4_header({
 			"allowed": d.allowed,
@@ -88,6 +93,17 @@ sg_ingress_v4_allowed(h) {
 #   Emits a decision entry describing the detail of a decision decision.api.shisho.dev/v1beta:aws_networking_sg_ingress_v4
 #
 #   The parameter `data` shoud be empty object (`{}`).
-sg_ingress_v4_payload(edata) = x {
+sg_ingress_v4_payload(edata) := x {
+	sg_ingress_v4_payload_assert(edata, "<the argument to sg_ingress_v4_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+sg_ingress_v4_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := []
+	every c in key_checks { c }
+
+	value_checks := []
+	every c in value_checks { c }
+} else := false

--- a/decision/aws/networking/networking_sg_ingress_v6.gen.rego
+++ b/decision/aws/networking/networking_sg_ingress_v6.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.networking
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure no security groups allow ingress from ::/0 to remote server administration ports
 # You can emit this decision as follows:
@@ -33,6 +37,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_networking_sg_ingress_v6".
 sg_ingress_v6(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": sg_ingress_v6_header({
 			"allowed": d.allowed,
@@ -87,6 +92,17 @@ sg_ingress_v6_allowed(h) {
 #   Emits a decision entry describing the detail of a decision decision.api.shisho.dev/v1beta:aws_networking_sg_ingress_v6
 #
 #   The parameter `data` shoud be empty object (`{}`).
-sg_ingress_v6_payload(edata) = x {
+sg_ingress_v6_payload(edata) := x {
+	sg_ingress_v6_payload_assert(edata, "<the argument to sg_ingress_v6_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+sg_ingress_v6_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := []
+	every c in key_checks { c }
+
+	value_checks := []
+	every c in value_checks { c }
+} else := false

--- a/decision/aws/networking/networking_vpc_flow_logging.gen.rego
+++ b/decision/aws/networking/networking_vpc_flow_logging.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.networking
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure AWS VPC flow logging is enabled
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_networking_vpc_flow_logging".
 vpc_flow_logging(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": vpc_flow_logging_header({
 			"allowed": d.allowed,
@@ -97,6 +102,21 @@ vpc_flow_logging_allowed(h) {
 #     "enabled": false,
 #   }
 #   ```
-vpc_flow_logging_payload(edata) = x {
+vpc_flow_logging_payload(edata) := x {
+	vpc_flow_logging_payload_assert(edata, "<the argument to vpc_flow_logging_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+vpc_flow_logging_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "enabled", concat("", [hint, ".", "enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [vpc_flow_logging_payload_assert_enabled(edata, "enabled", concat("", [hint, ".", "enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+vpc_flow_logging_payload_assert_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/aws/rds/rds_instance_accessibility.gen.rego
+++ b/decision/aws/rds/rds_instance_accessibility.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.rds
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that public access is not given to RDS instances
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_rds_instance_accessibility".
 instance_accessibility(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_accessibility_header({
 			"allowed": d.allowed,
@@ -97,6 +102,21 @@ instance_accessibility_allowed(h) {
 #     "is_publicly_accessible": false,
 #   }
 #   ```
-instance_accessibility_payload(edata) = x {
+instance_accessibility_payload(edata) := x {
+	instance_accessibility_payload_assert(edata, "<the argument to instance_accessibility_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_accessibility_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "is_publicly_accessible", concat("", [hint, ".", "is_publicly_accessible"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_accessibility_payload_assert_is_publicly_accessible(edata, "is_publicly_accessible", concat("", [hint, ".", "is_publicly_accessible"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_accessibility_payload_assert_is_publicly_accessible(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/aws/rds/rds_instance_auto_upgrade.gen.rego
+++ b/decision/aws/rds/rds_instance_auto_upgrade.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.rds
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure auto minor version upgrade feature is enabled for RDS instances
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_rds_instance_auto_upgrade".
 instance_auto_upgrade(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_auto_upgrade_header({
 			"allowed": d.allowed,
@@ -97,6 +102,21 @@ instance_auto_upgrade_allowed(h) {
 #     "enabled": false,
 #   }
 #   ```
-instance_auto_upgrade_payload(edata) = x {
+instance_auto_upgrade_payload(edata) := x {
+	instance_auto_upgrade_payload_assert(edata, "<the argument to instance_auto_upgrade_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_auto_upgrade_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "enabled", concat("", [hint, ".", "enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_auto_upgrade_payload_assert_enabled(edata, "enabled", concat("", [hint, ".", "enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_auto_upgrade_payload_assert_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/aws/s3/s3_bucket_access_logging.gen.rego
+++ b/decision/aws/s3/s3_bucket_access_logging.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.s3
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure access logging is enabled for important S3 buckets
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_s3_bucket_access_logging".
 bucket_access_logging(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": bucket_access_logging_header({
 			"allowed": d.allowed,
@@ -97,6 +102,21 @@ bucket_access_logging_allowed(h) {
 #     "enabled": false,
 #   }
 #   ```
-bucket_access_logging_payload(edata) = x {
+bucket_access_logging_payload(edata) := x {
+	bucket_access_logging_payload_assert(edata, "<the argument to bucket_access_logging_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+bucket_access_logging_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "enabled", concat("", [hint, ".", "enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [bucket_access_logging_payload_assert_enabled(edata, "enabled", concat("", [hint, ".", "enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+bucket_access_logging_payload_assert_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/aws/s3/s3_bucket_mfa_delete.gen.rego
+++ b/decision/aws/s3/s3_bucket_mfa_delete.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.s3
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure MFA Delete is enabled on S3 buckets
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_s3_bucket_mfa_delete".
 bucket_mfa_delete(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": bucket_mfa_delete_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ bucket_mfa_delete_allowed(h) {
 #     "mfa_enabled": false,
 #   }
 #   ```
-bucket_mfa_delete_payload(edata) = x {
+bucket_mfa_delete_payload(edata) := x {
+	bucket_mfa_delete_payload_assert(edata, "<the argument to bucket_mfa_delete_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+bucket_mfa_delete_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "mfa_enabled", concat("", [hint, ".", "mfa_enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [bucket_mfa_delete_payload_assert_mfa_enabled(edata, "mfa_enabled", concat("", [hint, ".", "mfa_enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+bucket_mfa_delete_payload_assert_mfa_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/aws/s3/s3_bucket_public_access_block.gen.rego
+++ b/decision/aws/s3/s3_bucket_public_access_block.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.aws.s3
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure S3 buckets enabled block public access feature
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:aws_s3_bucket_public_access_block".
 bucket_public_access_block(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": bucket_public_access_block_header({
 			"allowed": d.allowed,
@@ -97,6 +102,21 @@ bucket_public_access_block_allowed(h) {
 #     "enabled": false,
 #   }
 #   ```
-bucket_public_access_block_payload(edata) = x {
+bucket_public_access_block_payload(edata) := x {
+	bucket_public_access_block_payload_assert(edata, "<the argument to bucket_public_access_block_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+bucket_public_access_block_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "enabled", concat("", [hint, ".", "enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [bucket_public_access_block_payload_assert_enabled(edata, "enabled", concat("", [hint, ".", "enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+bucket_public_access_block_payload_assert_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/dependency/package.gen.rego
+++ b/decision/dependency/package.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.dependency
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Update packages with known vulnerabilities
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:package_known_vulnerability".
 package_known_vulnerability(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": package_known_vulnerability_header({
 			"allowed": d.allowed,
@@ -95,6 +100,101 @@ package_known_vulnerability_allowed(h) {
 #     "vulnerabilities": [{"name": "example", "version": "example", "vuln_constraint": "example", "vuln_id": "example", "vuln_namespace": "example", "advisories": ["example"], "description": "example", "found_at": "example"}],
 #   }
 #   ```
-package_known_vulnerability_payload(edata) = x {
+package_known_vulnerability_payload(edata) := x {
+	package_known_vulnerability_payload_assert(edata, "<the argument to package_known_vulnerability_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+package_known_vulnerability_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "vulnerabilities", concat("", [hint, ".", "vulnerabilities"]))]
+	every c in key_checks { c }
+
+	value_checks := [package_known_vulnerability_payload_assert_vulnerabilities(edata, "vulnerabilities", concat("", [hint, ".", "vulnerabilities"]))]
+	every c in value_checks { c }
+} else := false
+
+package_known_vulnerability_payload_assert_vulnerabilities(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [package_known_vulnerability_payload_assert_vulnerabilities_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+package_known_vulnerability_payload_assert_vulnerabilities_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "name", "string", hint),
+		assertion.has_typed_key(x[key], "version", "string", hint),
+		assertion.has_typed_key(x[key], "vuln_constraint", "string", hint),
+		assertion.has_typed_key(x[key], "vuln_id", "string", hint),
+		assertion.has_typed_key(x[key], "vuln_namespace", "string", hint),
+		assertion.has_typed_key(x[key], "advisories", "array", hint),
+		assertion.has_typed_key(x[key], "description", "string", hint),
+		assertion.has_typed_key(x[key], "found_at", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		package_known_vulnerability_payload_assert_vulnerabilities_element_name(x[key], "name", concat("", [hint, ".", "name"])),
+		package_known_vulnerability_payload_assert_vulnerabilities_element_version(x[key], "version", concat("", [hint, ".", "version"])),
+		package_known_vulnerability_payload_assert_vulnerabilities_element_vuln_constraint(x[key], "vuln_constraint", concat("", [hint, ".", "vuln_constraint"])),
+		package_known_vulnerability_payload_assert_vulnerabilities_element_vuln_id(x[key], "vuln_id", concat("", [hint, ".", "vuln_id"])),
+		package_known_vulnerability_payload_assert_vulnerabilities_element_vuln_namespace(x[key], "vuln_namespace", concat("", [hint, ".", "vuln_namespace"])),
+		package_known_vulnerability_payload_assert_vulnerabilities_element_advisories(x[key], "advisories", concat("", [hint, ".", "advisories"])),
+		package_known_vulnerability_payload_assert_vulnerabilities_element_description(x[key], "description", concat("", [hint, ".", "description"])),
+		package_known_vulnerability_payload_assert_vulnerabilities_element_found_at(x[key], "found_at", concat("", [hint, ".", "found_at"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+package_known_vulnerability_payload_assert_vulnerabilities_element_advisories(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [package_known_vulnerability_payload_assert_vulnerabilities_element_advisories_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+package_known_vulnerability_payload_assert_vulnerabilities_element_advisories_element(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+package_known_vulnerability_payload_assert_vulnerabilities_element_description(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+package_known_vulnerability_payload_assert_vulnerabilities_element_found_at(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+package_known_vulnerability_payload_assert_vulnerabilities_element_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+package_known_vulnerability_payload_assert_vulnerabilities_element_version(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+package_known_vulnerability_payload_assert_vulnerabilities_element_vuln_constraint(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+package_known_vulnerability_payload_assert_vulnerabilities_element_vuln_id(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+package_known_vulnerability_payload_assert_vulnerabilities_element_vuln_namespace(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/github/actions/actions.gen.rego
+++ b/decision/github/actions/actions.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.github.actions
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure dependencies of GitHub Actions workflows are pinned to verified versions
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_actions_dependency_pinning".
 dependency_pinning(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": dependency_pinning_header({
 			"allowed": d.allowed,
@@ -95,9 +100,67 @@ dependency_pinning_allowed(h) {
 #     "unpinned_dependencies": [{"path": "./.github/workflows/test.yaml", "line": 1, "column": 1, "dependency": "example"}],
 #   }
 #   ```
-dependency_pinning_payload(edata) = x {
+dependency_pinning_payload(edata) := x {
+	dependency_pinning_payload_assert(edata, "<the argument to dependency_pinning_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+dependency_pinning_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "unpinned_dependencies", concat("", [hint, ".", "unpinned_dependencies"]))]
+	every c in key_checks { c }
+
+	value_checks := [dependency_pinning_payload_assert_unpinned_dependencies(edata, "unpinned_dependencies", concat("", [hint, ".", "unpinned_dependencies"]))]
+	every c in value_checks { c }
+} else := false
+
+dependency_pinning_payload_assert_unpinned_dependencies(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [dependency_pinning_payload_assert_unpinned_dependencies_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+dependency_pinning_payload_assert_unpinned_dependencies_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "path", "string", hint),
+		assertion.has_typed_key(x[key], "line", "number", hint),
+		assertion.has_typed_key(x[key], "column", "number", hint),
+		assertion.has_typed_key(x[key], "dependency", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		dependency_pinning_payload_assert_unpinned_dependencies_element_path(x[key], "path", concat("", [hint, ".", "path"])),
+		dependency_pinning_payload_assert_unpinned_dependencies_element_line(x[key], "line", concat("", [hint, ".", "line"])),
+		dependency_pinning_payload_assert_unpinned_dependencies_element_column(x[key], "column", concat("", [hint, ".", "column"])),
+		dependency_pinning_payload_assert_unpinned_dependencies_element_dependency(x[key], "dependency", concat("", [hint, ".", "dependency"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+dependency_pinning_payload_assert_unpinned_dependencies_element_column(x, key, hint) {
+	assertion.is_type(x[key], "number", hint)
+} else := false
+
+dependency_pinning_payload_assert_unpinned_dependencies_element_dependency(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+dependency_pinning_payload_assert_unpinned_dependencies_element_line(x, key, hint) {
+	assertion.is_type(x[key], "number", hint)
+} else := false
+
+dependency_pinning_payload_assert_unpinned_dependencies_element_path(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
 
 # @title Ensure script evaluation by GitHub Actions workflows is validated
 # You can emit this decision as follows:
@@ -128,6 +191,7 @@ dependency_pinning_payload(edata) = x {
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_actions_insecure_script_evaluation".
 insecure_script_evaluation(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": insecure_script_evaluation_header({
 			"allowed": d.allowed,
@@ -189,9 +253,67 @@ insecure_script_evaluation_allowed(h) {
 #     "evaluated_scripts": [{"path": "./.github/workflows/test.yaml", "source_command": curl -s http://example.com, "line": 1, "column": 1}],
 #   }
 #   ```
-insecure_script_evaluation_payload(edata) = x {
+insecure_script_evaluation_payload(edata) := x {
+	insecure_script_evaluation_payload_assert(edata, "<the argument to insecure_script_evaluation_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+insecure_script_evaluation_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "evaluated_scripts", concat("", [hint, ".", "evaluated_scripts"]))]
+	every c in key_checks { c }
+
+	value_checks := [insecure_script_evaluation_payload_assert_evaluated_scripts(edata, "evaluated_scripts", concat("", [hint, ".", "evaluated_scripts"]))]
+	every c in value_checks { c }
+} else := false
+
+insecure_script_evaluation_payload_assert_evaluated_scripts(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [insecure_script_evaluation_payload_assert_evaluated_scripts_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+insecure_script_evaluation_payload_assert_evaluated_scripts_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "path", "string", hint),
+		assertion.has_typed_key(x[key], "source_command", "string", hint),
+		assertion.has_typed_key(x[key], "line", "number", hint),
+		assertion.has_typed_key(x[key], "column", "number", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		insecure_script_evaluation_payload_assert_evaluated_scripts_element_path(x[key], "path", concat("", [hint, ".", "path"])),
+		insecure_script_evaluation_payload_assert_evaluated_scripts_element_source_command(x[key], "source_command", concat("", [hint, ".", "source_command"])),
+		insecure_script_evaluation_payload_assert_evaluated_scripts_element_line(x[key], "line", concat("", [hint, ".", "line"])),
+		insecure_script_evaluation_payload_assert_evaluated_scripts_element_column(x[key], "column", concat("", [hint, ".", "column"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+insecure_script_evaluation_payload_assert_evaluated_scripts_element_column(x, key, hint) {
+	assertion.is_type(x[key], "number", hint)
+} else := false
+
+insecure_script_evaluation_payload_assert_evaluated_scripts_element_line(x, key, hint) {
+	assertion.is_type(x[key], "number", hint)
+} else := false
+
+insecure_script_evaluation_payload_assert_evaluated_scripts_element_path(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+insecure_script_evaluation_payload_assert_evaluated_scripts_element_source_command(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
 
 # @title Ensure explicit permissions for GitHub Actions workflows follow organization policies
 # You can emit this decision as follows:
@@ -222,6 +344,7 @@ insecure_script_evaluation_payload(edata) = x {
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_actions_workflow_explicit_permissions".
 workflow_explicit_permissions(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": workflow_explicit_permissions_header({
 			"allowed": d.allowed,
@@ -283,9 +406,68 @@ workflow_explicit_permissions_allowed(h) {
 #     "workflows_with_excessive_permissions": [{"path": "./.github/workflows/test.yaml", "excessive_permissions": ["example"]}],
 #   }
 #   ```
-workflow_explicit_permissions_payload(edata) = x {
+workflow_explicit_permissions_payload(edata) := x {
+	workflow_explicit_permissions_payload_assert(edata, "<the argument to workflow_explicit_permissions_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+workflow_explicit_permissions_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "workflows_with_excessive_permissions", concat("", [hint, ".", "workflows_with_excessive_permissions"]))]
+	every c in key_checks { c }
+
+	value_checks := [workflow_explicit_permissions_payload_assert_workflows_with_excessive_permissions(edata, "workflows_with_excessive_permissions", concat("", [hint, ".", "workflows_with_excessive_permissions"]))]
+	every c in value_checks { c }
+} else := false
+
+workflow_explicit_permissions_payload_assert_workflows_with_excessive_permissions(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [workflow_explicit_permissions_payload_assert_workflows_with_excessive_permissions_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+workflow_explicit_permissions_payload_assert_workflows_with_excessive_permissions_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "path", "string", hint),
+		assertion.has_typed_key(x[key], "excessive_permissions", "array", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		workflow_explicit_permissions_payload_assert_workflows_with_excessive_permissions_element_path(x[key], "path", concat("", [hint, ".", "path"])),
+		workflow_explicit_permissions_payload_assert_workflows_with_excessive_permissions_element_excessive_permissions(x[key], "excessive_permissions", concat("", [hint, ".", "excessive_permissions"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+workflow_explicit_permissions_payload_assert_workflows_with_excessive_permissions_element_excessive_permissions(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [workflow_explicit_permissions_payload_assert_workflows_with_excessive_permissions_element_excessive_permissions_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+workflow_explicit_permissions_payload_assert_workflows_with_excessive_permissions_element_excessive_permissions_element(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+workflow_explicit_permissions_payload_assert_workflows_with_excessive_permissions_element_path(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
 
 # @title Ensure GitHub Actions workflows do not permit any script injections
 # You can emit this decision as follows:
@@ -316,6 +498,7 @@ workflow_explicit_permissions_payload(edata) = x {
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_actions_workflow_script_injection_possibility".
 workflow_script_injection_possibility(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": workflow_script_injection_possibility_header({
 			"allowed": d.allowed,
@@ -377,9 +560,80 @@ workflow_script_injection_possibility_allowed(h) {
 #     "injectable_sinks": [{"path": "./.github/workflows/test.yaml", "line": 1, "column": 1, "abusable_fields": ["example"]}],
 #   }
 #   ```
-workflow_script_injection_possibility_payload(edata) = x {
+workflow_script_injection_possibility_payload(edata) := x {
+	workflow_script_injection_possibility_payload_assert(edata, "<the argument to workflow_script_injection_possibility_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+workflow_script_injection_possibility_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "injectable_sinks", concat("", [hint, ".", "injectable_sinks"]))]
+	every c in key_checks { c }
+
+	value_checks := [workflow_script_injection_possibility_payload_assert_injectable_sinks(edata, "injectable_sinks", concat("", [hint, ".", "injectable_sinks"]))]
+	every c in value_checks { c }
+} else := false
+
+workflow_script_injection_possibility_payload_assert_injectable_sinks(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [workflow_script_injection_possibility_payload_assert_injectable_sinks_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+workflow_script_injection_possibility_payload_assert_injectable_sinks_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "path", "string", hint),
+		assertion.has_typed_key(x[key], "line", "number", hint),
+		assertion.has_typed_key(x[key], "column", "number", hint),
+		assertion.has_typed_key(x[key], "abusable_fields", "array", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		workflow_script_injection_possibility_payload_assert_injectable_sinks_element_path(x[key], "path", concat("", [hint, ".", "path"])),
+		workflow_script_injection_possibility_payload_assert_injectable_sinks_element_line(x[key], "line", concat("", [hint, ".", "line"])),
+		workflow_script_injection_possibility_payload_assert_injectable_sinks_element_column(x[key], "column", concat("", [hint, ".", "column"])),
+		workflow_script_injection_possibility_payload_assert_injectable_sinks_element_abusable_fields(x[key], "abusable_fields", concat("", [hint, ".", "abusable_fields"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+workflow_script_injection_possibility_payload_assert_injectable_sinks_element_abusable_fields(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [workflow_script_injection_possibility_payload_assert_injectable_sinks_element_abusable_fields_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+workflow_script_injection_possibility_payload_assert_injectable_sinks_element_abusable_fields_element(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+workflow_script_injection_possibility_payload_assert_injectable_sinks_element_column(x, key, hint) {
+	assertion.is_type(x[key], "number", hint)
+} else := false
+
+workflow_script_injection_possibility_payload_assert_injectable_sinks_element_line(x, key, hint) {
+	assertion.is_type(x[key], "number", hint)
+} else := false
+
+workflow_script_injection_possibility_payload_assert_injectable_sinks_element_path(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
 
 # @title Ensure secrets do not appear in GitHub Actions Workflows directly
 # You can emit this decision as follows:
@@ -410,6 +664,7 @@ workflow_script_injection_possibility_payload(edata) = x {
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_actions_workflow_secret_handling".
 workflow_secret_handling(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": workflow_secret_handling_header({
 			"allowed": d.allowed,
@@ -471,6 +726,64 @@ workflow_secret_handling_allowed(h) {
 #     "hardcoded_secrets": [{"path": "./.github/workflows/test.yaml", "line": 1, "column": 1, "location_hint": "example"}],
 #   }
 #   ```
-workflow_secret_handling_payload(edata) = x {
+workflow_secret_handling_payload(edata) := x {
+	workflow_secret_handling_payload_assert(edata, "<the argument to workflow_secret_handling_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+workflow_secret_handling_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "hardcoded_secrets", concat("", [hint, ".", "hardcoded_secrets"]))]
+	every c in key_checks { c }
+
+	value_checks := [workflow_secret_handling_payload_assert_hardcoded_secrets(edata, "hardcoded_secrets", concat("", [hint, ".", "hardcoded_secrets"]))]
+	every c in value_checks { c }
+} else := false
+
+workflow_secret_handling_payload_assert_hardcoded_secrets(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [workflow_secret_handling_payload_assert_hardcoded_secrets_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+workflow_secret_handling_payload_assert_hardcoded_secrets_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "path", "string", hint),
+		assertion.has_typed_key(x[key], "line", "number", hint),
+		assertion.has_typed_key(x[key], "column", "number", hint),
+		assertion.has_typed_key(x[key], "location_hint", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		workflow_secret_handling_payload_assert_hardcoded_secrets_element_path(x[key], "path", concat("", [hint, ".", "path"])),
+		workflow_secret_handling_payload_assert_hardcoded_secrets_element_line(x[key], "line", concat("", [hint, ".", "line"])),
+		workflow_secret_handling_payload_assert_hardcoded_secrets_element_column(x[key], "column", concat("", [hint, ".", "column"])),
+		workflow_secret_handling_payload_assert_hardcoded_secrets_element_location_hint(x[key], "location_hint", concat("", [hint, ".", "location_hint"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+workflow_secret_handling_payload_assert_hardcoded_secrets_element_column(x, key, hint) {
+	assertion.is_type(x[key], "number", hint)
+} else := false
+
+workflow_secret_handling_payload_assert_hardcoded_secrets_element_line(x, key, hint) {
+	assertion.is_type(x[key], "number", hint)
+} else := false
+
+workflow_secret_handling_payload_assert_hardcoded_secrets_element_location_hint(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+workflow_secret_handling_payload_assert_hardcoded_secrets_element_path(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/github/organization.gen.rego
+++ b/decision/github/organization.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.github
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Enforce two-factor authentication on GitHub organization(s)
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_org_2fa_status".
 org_2fa_status(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": org_2fa_status_header({
 			"allowed": d.allowed,
@@ -95,9 +100,24 @@ org_2fa_status_allowed(h) {
 #     "enabled": false,
 #   }
 #   ```
-org_2fa_status_payload(edata) = x {
+org_2fa_status_payload(edata) := x {
+	org_2fa_status_payload_assert(edata, "<the argument to org_2fa_status_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+org_2fa_status_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "enabled", concat("", [hint, ".", "enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [org_2fa_status_payload_assert_enabled(edata, "enabled", concat("", [hint, ".", "enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+org_2fa_status_payload_assert_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false
 
 # @title Ensure strict base permissions are set for repositories
 # You can emit this decision as follows:
@@ -128,6 +148,7 @@ org_2fa_status_payload(edata) = x {
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_org_default_repository_permission".
 org_default_repository_permission(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": org_default_repository_permission_header({
 			"allowed": d.allowed,
@@ -189,9 +210,24 @@ org_default_repository_permission_allowed(h) {
 #     "current": "example",
 #   }
 #   ```
-org_default_repository_permission_payload(edata) = x {
+org_default_repository_permission_payload(edata) := x {
+	org_default_repository_permission_payload_assert(edata, "<the argument to org_default_repository_permission_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+org_default_repository_permission_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "current", concat("", [hint, ".", "current"]))]
+	every c in key_checks { c }
+
+	value_checks := [org_default_repository_permission_payload_assert_current(edata, "current", concat("", [hint, ".", "current"]))]
+	every c in value_checks { c }
+} else := false
+
+org_default_repository_permission_payload_assert_current(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
 
 # @title Ensure creation of GitHub public pages is restricted
 # You can emit this decision as follows:
@@ -222,6 +258,7 @@ org_default_repository_permission_payload(edata) = x {
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_org_members_permission_on_creating_public_pages".
 org_members_permission_on_creating_public_pages(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": org_members_permission_on_creating_public_pages_header({
 			"allowed": d.allowed,
@@ -280,9 +317,24 @@ org_members_permission_on_creating_public_pages_allowed(h) {
 #     "allowed": false,
 #   }
 #   ```
-org_members_permission_on_creating_public_pages_payload(edata) = x {
+org_members_permission_on_creating_public_pages_payload(edata) := x {
+	org_members_permission_on_creating_public_pages_payload_assert(edata, "<the argument to org_members_permission_on_creating_public_pages_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+org_members_permission_on_creating_public_pages_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "allowed", concat("", [hint, ".", "allowed"]))]
+	every c in key_checks { c }
+
+	value_checks := [org_members_permission_on_creating_public_pages_payload_assert_allowed(edata, "allowed", concat("", [hint, ".", "allowed"]))]
+	every c in value_checks { c }
+} else := false
+
+org_members_permission_on_creating_public_pages_payload_assert_allowed(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false
 
 # @title Ensure public repository creation is limited to specific members
 # You can emit this decision as follows:
@@ -313,6 +365,7 @@ org_members_permission_on_creating_public_pages_payload(edata) = x {
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_org_members_permission_on_creating_public_repos".
 org_members_permission_on_creating_public_repos(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": org_members_permission_on_creating_public_repos_header({
 			"allowed": d.allowed,
@@ -374,9 +427,24 @@ org_members_permission_on_creating_public_repos_allowed(h) {
 #     "allowed": false,
 #   }
 #   ```
-org_members_permission_on_creating_public_repos_payload(edata) = x {
+org_members_permission_on_creating_public_repos_payload(edata) := x {
+	org_members_permission_on_creating_public_repos_payload_assert(edata, "<the argument to org_members_permission_on_creating_public_repos_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+org_members_permission_on_creating_public_repos_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "allowed", concat("", [hint, ".", "allowed"]))]
+	every c in key_checks { c }
+
+	value_checks := [org_members_permission_on_creating_public_repos_payload_assert_allowed(edata, "allowed", concat("", [hint, ".", "allowed"]))]
+	every c in value_checks { c }
+} else := false
+
+org_members_permission_on_creating_public_repos_payload_assert_allowed(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false
 
 # @title Ensure forking of GitHub repositories is restricted
 # You can emit this decision as follows:
@@ -407,6 +475,7 @@ org_members_permission_on_creating_public_repos_payload(edata) = x {
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_org_members_permission_on_private_forking".
 org_members_permission_on_private_forking(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": org_members_permission_on_private_forking_header({
 			"allowed": d.allowed,
@@ -465,9 +534,24 @@ org_members_permission_on_private_forking_allowed(h) {
 #     "allowed": false,
 #   }
 #   ```
-org_members_permission_on_private_forking_payload(edata) = x {
+org_members_permission_on_private_forking_payload(edata) := x {
+	org_members_permission_on_private_forking_payload_assert(edata, "<the argument to org_members_permission_on_private_forking_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+org_members_permission_on_private_forking_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "allowed", concat("", [hint, ".", "allowed"]))]
+	every c in key_checks { c }
+
+	value_checks := [org_members_permission_on_private_forking_payload_assert_allowed(edata, "allowed", concat("", [hint, ".", "allowed"]))]
+	every c in value_checks { c }
+} else := false
+
+org_members_permission_on_private_forking_payload_assert_allowed(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false
 
 # @title Ensure minimum number of administrators are set for the organization
 # You can emit this decision as follows:
@@ -498,6 +582,7 @@ org_members_permission_on_private_forking_payload(edata) = x {
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_org_owners".
 org_owners(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": org_owners_header({
 			"allowed": d.allowed,
@@ -559,6 +644,34 @@ org_owners_allowed(h) {
 #     "admins": ["example"],
 #   }
 #   ```
-org_owners_payload(edata) = x {
+org_owners_payload(edata) := x {
+	org_owners_payload_assert(edata, "<the argument to org_owners_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+org_owners_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "admins", concat("", [hint, ".", "admins"]))]
+	every c in key_checks { c }
+
+	value_checks := [org_owners_payload_assert_admins(edata, "admins", concat("", [hint, ".", "admins"]))]
+	every c in value_checks { c }
+} else := false
+
+org_owners_payload_assert_admins(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [org_owners_payload_assert_admins_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+org_owners_payload_assert_admins_element(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/github/repository.gen.rego
+++ b/decision/github/repository.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.github
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure the deletion of protected branches is limited
 # You can emit this decision as follows:
@@ -35,6 +39,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_branch_deletion_policy".
 branch_deletion_policy(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": branch_deletion_policy_header({
 			"allowed": d.allowed,
@@ -98,9 +103,34 @@ branch_deletion_policy_allowed(h) {
 #     "subject_branch": "example",
 #   }
 #   ```
-branch_deletion_policy_payload(edata) = x {
+branch_deletion_policy_payload(edata) := x {
+	branch_deletion_policy_payload_assert(edata, "<the argument to branch_deletion_policy_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+branch_deletion_policy_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "allowed", concat("", [hint, ".", "allowed"])),
+		assertion.has_key(edata, "subject_branch", concat("", [hint, ".", "subject_branch"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		branch_deletion_policy_payload_assert_allowed(edata, "allowed", concat("", [hint, ".", "allowed"])),
+		branch_deletion_policy_payload_assert_subject_branch(edata, "subject_branch", concat("", [hint, ".", "subject_branch"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+branch_deletion_policy_payload_assert_allowed(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false
+
+branch_deletion_policy_payload_assert_subject_branch(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
 
 # @title Ensure code owner’s review is required when a change affects owned code
 # You can emit this decision as follows:
@@ -132,6 +162,7 @@ branch_deletion_policy_payload(edata) = x {
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_code_owners_review_policy".
 code_owners_review_policy(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": code_owners_review_policy_header({
 			"allowed": d.allowed,
@@ -195,9 +226,34 @@ code_owners_review_policy_allowed(h) {
 #     "subject_branch": "example",
 #   }
 #   ```
-code_owners_review_policy_payload(edata) = x {
+code_owners_review_policy_payload(edata) := x {
+	code_owners_review_policy_payload_assert(edata, "<the argument to code_owners_review_policy_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+code_owners_review_policy_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "required", concat("", [hint, ".", "required"])),
+		assertion.has_key(edata, "subject_branch", concat("", [hint, ".", "subject_branch"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		code_owners_review_policy_payload_assert_required(edata, "required", concat("", [hint, ".", "required"])),
+		code_owners_review_policy_payload_assert_subject_branch(edata, "subject_branch", concat("", [hint, ".", "subject_branch"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+code_owners_review_policy_payload_assert_required(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false
+
+code_owners_review_policy_payload_assert_subject_branch(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
 
 # @title Ensure verification of signed commits for new changes before merging
 # You can emit this decision as follows:
@@ -229,6 +285,7 @@ code_owners_review_policy_payload(edata) = x {
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_commit_signature_policy".
 commit_signature_policy(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": commit_signature_policy_header({
 			"allowed": d.allowed,
@@ -292,9 +349,34 @@ commit_signature_policy_allowed(h) {
 #     "subject_branch": "example",
 #   }
 #   ```
-commit_signature_policy_payload(edata) = x {
+commit_signature_policy_payload(edata) := x {
+	commit_signature_policy_payload_assert(edata, "<the argument to commit_signature_policy_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+commit_signature_policy_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "required", concat("", [hint, ".", "required"])),
+		assertion.has_key(edata, "subject_branch", concat("", [hint, ".", "subject_branch"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		commit_signature_policy_payload_assert_required(edata, "required", concat("", [hint, ".", "required"])),
+		commit_signature_policy_payload_assert_subject_branch(edata, "subject_branch", concat("", [hint, ".", "subject_branch"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+commit_signature_policy_payload_assert_required(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false
+
+commit_signature_policy_payload_assert_subject_branch(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
 
 # @title Keep a default branch protected by branch protection rule(s)
 # You can emit this decision as follows:
@@ -325,6 +407,7 @@ commit_signature_policy_payload(edata) = x {
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_default_branch_protection".
 default_branch_protection(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": default_branch_protection_header({
 			"allowed": d.allowed,
@@ -386,9 +469,24 @@ default_branch_protection_allowed(h) {
 #     "default_branch_name": "example",
 #   }
 #   ```
-default_branch_protection_payload(edata) = x {
+default_branch_protection_payload(edata) := x {
+	default_branch_protection_payload_assert(edata, "<the argument to default_branch_protection_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+default_branch_protection_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "default_branch_name", concat("", [hint, ".", "default_branch_name"]))]
+	every c in key_checks { c }
+
+	value_checks := [default_branch_protection_payload_assert_default_branch_name(edata, "default_branch_name", concat("", [hint, ".", "default_branch_name"]))]
+	every c in value_checks { c }
+} else := false
+
+default_branch_protection_payload_assert_default_branch_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
 
 # @title Ensure force push code to branches is denied
 # You can emit this decision as follows:
@@ -420,6 +518,7 @@ default_branch_protection_payload(edata) = x {
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_force_push_policy".
 force_push_policy(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": force_push_policy_header({
 			"allowed": d.allowed,
@@ -483,9 +582,34 @@ force_push_policy_allowed(h) {
 #     "subject_branch": "example",
 #   }
 #   ```
-force_push_policy_payload(edata) = x {
+force_push_policy_payload(edata) := x {
+	force_push_policy_payload_assert(edata, "<the argument to force_push_policy_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+force_push_policy_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "allowed", concat("", [hint, ".", "allowed"])),
+		assertion.has_key(edata, "subject_branch", concat("", [hint, ".", "subject_branch"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		force_push_policy_payload_assert_allowed(edata, "allowed", concat("", [hint, ".", "allowed"])),
+		force_push_policy_payload_assert_subject_branch(edata, "subject_branch", concat("", [hint, ".", "subject_branch"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+force_push_policy_payload_assert_allowed(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false
+
+force_push_policy_payload_assert_subject_branch(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
 
 # @title Ensure linear history is required
 # You can emit this decision as follows:
@@ -517,6 +641,7 @@ force_push_policy_payload(edata) = x {
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_linear_history_policy".
 linear_history_policy(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": linear_history_policy_header({
 			"allowed": d.allowed,
@@ -580,9 +705,34 @@ linear_history_policy_allowed(h) {
 #     "subject_branch": "example",
 #   }
 #   ```
-linear_history_policy_payload(edata) = x {
+linear_history_policy_payload(edata) := x {
+	linear_history_policy_payload_assert(edata, "<the argument to linear_history_policy_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+linear_history_policy_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "required", concat("", [hint, ".", "required"])),
+		assertion.has_key(edata, "subject_branch", concat("", [hint, ".", "subject_branch"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		linear_history_policy_payload_assert_required(edata, "required", concat("", [hint, ".", "required"])),
+		linear_history_policy_payload_assert_subject_branch(edata, "subject_branch", concat("", [hint, ".", "subject_branch"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+linear_history_policy_payload_assert_required(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false
+
+linear_history_policy_payload_assert_subject_branch(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
 
 # @title Ensure any change to code receives the enough number of approvals by authenticated users
 # You can emit this decision as follows:
@@ -614,6 +764,7 @@ linear_history_policy_payload(edata) = x {
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_minimum_approval_number_policy".
 minimum_approval_number_policy(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": minimum_approval_number_policy_header({
 			"allowed": d.allowed,
@@ -677,9 +828,34 @@ minimum_approval_number_policy_allowed(h) {
 #     "subject_branch": "example",
 #   }
 #   ```
-minimum_approval_number_policy_payload(edata) = x {
+minimum_approval_number_policy_payload(edata) := x {
+	minimum_approval_number_policy_payload_assert(edata, "<the argument to minimum_approval_number_policy_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+minimum_approval_number_policy_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "required_approval_count", concat("", [hint, ".", "required_approval_count"])),
+		assertion.has_key(edata, "subject_branch", concat("", [hint, ".", "subject_branch"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		minimum_approval_number_policy_payload_assert_required_approval_count(edata, "required_approval_count", concat("", [hint, ".", "required_approval_count"])),
+		minimum_approval_number_policy_payload_assert_subject_branch(edata, "subject_branch", concat("", [hint, ".", "subject_branch"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+minimum_approval_number_policy_payload_assert_required_approval_count(x, key, hint) {
+	assertion.is_type(x[key], "number", hint)
+} else := false
+
+minimum_approval_number_policy_payload_assert_subject_branch(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
 
 # @title Ensure branch protection rules are enforced for administrators
 # You can emit this decision as follows:
@@ -711,6 +887,7 @@ minimum_approval_number_policy_payload(edata) = x {
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_protection_enforcement_for_admins".
 protection_enforcement_for_admins(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": protection_enforcement_for_admins_header({
 			"allowed": d.allowed,
@@ -774,9 +951,34 @@ protection_enforcement_for_admins_allowed(h) {
 #     "subject_branch": "example",
 #   }
 #   ```
-protection_enforcement_for_admins_payload(edata) = x {
+protection_enforcement_for_admins_payload(edata) := x {
+	protection_enforcement_for_admins_payload_assert(edata, "<the argument to protection_enforcement_for_admins_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+protection_enforcement_for_admins_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "allowed", concat("", [hint, ".", "allowed"])),
+		assertion.has_key(edata, "subject_branch", concat("", [hint, ".", "subject_branch"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		protection_enforcement_for_admins_payload_assert_allowed(edata, "allowed", concat("", [hint, ".", "allowed"])),
+		protection_enforcement_for_admins_payload_assert_subject_branch(edata, "subject_branch", concat("", [hint, ".", "subject_branch"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+protection_enforcement_for_admins_payload_assert_allowed(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false
+
+protection_enforcement_for_admins_payload_assert_subject_branch(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
 
 # @title Ensure minimum number of administrators are set for the GitHub repository
 # You can emit this decision as follows:
@@ -807,6 +1009,7 @@ protection_enforcement_for_admins_payload(edata) = x {
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_repo_admins".
 repo_admins(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": repo_admins_header({
 			"allowed": d.allowed,
@@ -868,9 +1071,37 @@ repo_admins_allowed(h) {
 #     "admins": ["example"],
 #   }
 #   ```
-repo_admins_payload(edata) = x {
+repo_admins_payload(edata) := x {
+	repo_admins_payload_assert(edata, "<the argument to repo_admins_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+repo_admins_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "admins", concat("", [hint, ".", "admins"]))]
+	every c in key_checks { c }
+
+	value_checks := [repo_admins_payload_assert_admins(edata, "admins", concat("", [hint, ".", "admins"]))]
+	every c in value_checks { c }
+} else := false
+
+repo_admins_payload_assert_admins(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [repo_admins_payload_assert_admins_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+repo_admins_payload_assert_admins_element(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
 
 # @title Ensure deletion of GitHub repositories is restricted
 # You can emit this decision as follows:
@@ -901,6 +1132,7 @@ repo_admins_payload(edata) = x {
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_repo_members_permission_on_deleting_repository".
 repo_members_permission_on_deleting_repository(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": repo_members_permission_on_deleting_repository_header({
 			"allowed": d.allowed,
@@ -962,9 +1194,37 @@ repo_members_permission_on_deleting_repository_allowed(h) {
 #     "allowed_users": ["example"],
 #   }
 #   ```
-repo_members_permission_on_deleting_repository_payload(edata) = x {
+repo_members_permission_on_deleting_repository_payload(edata) := x {
+	repo_members_permission_on_deleting_repository_payload_assert(edata, "<the argument to repo_members_permission_on_deleting_repository_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+repo_members_permission_on_deleting_repository_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "allowed_users", concat("", [hint, ".", "allowed_users"]))]
+	every c in key_checks { c }
+
+	value_checks := [repo_members_permission_on_deleting_repository_payload_assert_allowed_users(edata, "allowed_users", concat("", [hint, ".", "allowed_users"]))]
+	every c in value_checks { c }
+} else := false
+
+repo_members_permission_on_deleting_repository_payload_assert_allowed_users(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [repo_members_permission_on_deleting_repository_payload_assert_allowed_users_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+repo_members_permission_on_deleting_repository_payload_assert_allowed_users_element(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
 
 # @title Ensure previous approvals are dismissed when updates are introduced to a code change proposal
 # You can emit this decision as follows:
@@ -996,6 +1256,7 @@ repo_members_permission_on_deleting_repository_payload(edata) = x {
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:github_stale_review_policy".
 stale_review_policy(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": stale_review_policy_header({
 			"allowed": d.allowed,
@@ -1059,6 +1320,31 @@ stale_review_policy_allowed(h) {
 #     "subject_branch": "example",
 #   }
 #   ```
-stale_review_policy_payload(edata) = x {
+stale_review_policy_payload(edata) := x {
+	stale_review_policy_payload_assert(edata, "<the argument to stale_review_policy_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+stale_review_policy_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "enforced", concat("", [hint, ".", "enforced"])),
+		assertion.has_key(edata, "subject_branch", concat("", [hint, ".", "subject_branch"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		stale_review_policy_payload_assert_enforced(edata, "enforced", concat("", [hint, ".", "enforced"])),
+		stale_review_policy_payload_assert_subject_branch(edata, "subject_branch", concat("", [hint, ".", "subject_branch"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+stale_review_policy_payload_assert_enforced(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false
+
+stale_review_policy_payload_assert_subject_branch(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/appengine/appengine_http.gen.rego
+++ b/decision/googlecloud/appengine/appengine_http.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.appengine
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure App Engine applications enforce HTTPS connections
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_appengine_http".
 http(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": http_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ http_allowed(h) {
 #     "accepted": false,
 #   }
 #   ```
-http_payload(edata) = x {
+http_payload(edata) := x {
+	http_payload_assert(edata, "<the argument to http_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+http_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "accepted", concat("", [hint, ".", "accepted"]))]
+	every c in key_checks { c }
+
+	value_checks := [http_payload_assert_accepted(edata, "accepted", concat("", [hint, ".", "accepted"]))]
+	every c in value_checks { c }
+} else := false
+
+http_payload_assert_accepted(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/googlecloud/asset/asset_management.gen.rego
+++ b/decision/googlecloud/asset/asset_management.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.asset
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure Google Cloud assets and their changes are recorded
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_asset_management".
 management(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": management_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ management_allowed(h) {
 #     "enabled": false,
 #   }
 #   ```
-management_payload(edata) = x {
+management_payload(edata) := x {
+	management_payload_assert(edata, "<the argument to management_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+management_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "enabled", concat("", [hint, ".", "enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [management_payload_assert_enabled(edata, "enabled", concat("", [hint, ".", "enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+management_payload_assert_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/googlecloud/bigquery/bigquery_dataset_accessibility.gen.rego
+++ b/decision/googlecloud/bigquery/bigquery_dataset_accessibility.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.bigquery
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure BigQuery dataset accessibility is restricted to a minimum level
 # You can emit this decision as follows:
@@ -22,8 +26,8 @@ import data.shisho
 #     "allowed": allowed,
 #     "subject": subject,
 #     "payload": shisho.decision.googlecloud.bigquery.dataset_accessibility_payload({
-#       "all_authenticated_users_roles": ["example"],
-#       "all_users_roles": ["example"],
+#       "all_authenticated_users_roles": [{"id": "example"}],
+#       "all_users_roles": [{"id": "example"}],
 #     }),
 #   })
 # }
@@ -35,6 +39,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_bigquery_dataset_accessibility".
 dataset_accessibility(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": dataset_accessibility_header({
 			"allowed": d.allowed,
@@ -89,16 +94,83 @@ dataset_accessibility_allowed(h) {
 #   Emits a decision entry describing the detail of a decision decision.api.shisho.dev/v1beta:googlecloud_bigquery_dataset_accessibility
 #
 #   The parameter `data` is an object with the following fields: 
-#   - all_authenticated_users_roles: string
-#   - all_users_roles: string
+#   - all_authenticated_users_roles: {"id": string}
+#   - all_users_roles: {"id": string}
 #
 #   For instance, `data` can take the following value:
 #   ```rego
 #   {
-#     "all_authenticated_users_roles": ["example"],
-#     "all_users_roles": ["example"],
+#     "all_authenticated_users_roles": [{"id": "example"}],
+#     "all_users_roles": [{"id": "example"}],
 #   }
 #   ```
-dataset_accessibility_payload(edata) = x {
+dataset_accessibility_payload(edata) := x {
+	dataset_accessibility_payload_assert(edata, "<the argument to dataset_accessibility_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+dataset_accessibility_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "all_authenticated_users_roles", concat("", [hint, ".", "all_authenticated_users_roles"])),
+		assertion.has_key(edata, "all_users_roles", concat("", [hint, ".", "all_users_roles"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		dataset_accessibility_payload_assert_all_authenticated_users_roles(edata, "all_authenticated_users_roles", concat("", [hint, ".", "all_authenticated_users_roles"])),
+		dataset_accessibility_payload_assert_all_users_roles(edata, "all_users_roles", concat("", [hint, ".", "all_users_roles"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+dataset_accessibility_payload_assert_all_authenticated_users_roles(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [dataset_accessibility_payload_assert_all_authenticated_users_roles_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+dataset_accessibility_payload_assert_all_authenticated_users_roles_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [assertion.has_typed_key(x[key], "id", "string", hint)]
+	every c in key_checks { c }
+	value_checks := [dataset_accessibility_payload_assert_all_authenticated_users_roles_element_id(x[key], "id", concat("", [hint, ".", "id"]))]
+	every c in value_checks { c }
+} else := false
+
+dataset_accessibility_payload_assert_all_authenticated_users_roles_element_id(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+dataset_accessibility_payload_assert_all_users_roles(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [dataset_accessibility_payload_assert_all_users_roles_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+dataset_accessibility_payload_assert_all_users_roles_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [assertion.has_typed_key(x[key], "id", "string", hint)]
+	every c in key_checks { c }
+	value_checks := [dataset_accessibility_payload_assert_all_users_roles_element_id(x[key], "id", concat("", [hint, ".", "id"]))]
+	every c in value_checks { c }
+} else := false
+
+dataset_accessibility_payload_assert_all_users_roles_element_id(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/bigquery/bigquery_dataset_encryption_cmek.gen.rego
+++ b/decision/googlecloud/bigquery/bigquery_dataset_encryption_cmek.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.bigquery
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure BigQuery tables use Customer-Managed Encryption Keys (CMEK)
 # You can emit this decision as follows:
@@ -35,6 +39,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_bigquery_dataset_encryption_cmek".
 dataset_encryption_cmek(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": dataset_encryption_cmek_header({
 			"allowed": d.allowed,
@@ -99,6 +104,31 @@ dataset_encryption_cmek_allowed(h) {
 #     "uses_default_key": false,
 #   }
 #   ```
-dataset_encryption_cmek_payload(edata) = x {
+dataset_encryption_cmek_payload(edata) := x {
+	dataset_encryption_cmek_payload_assert(edata, "<the argument to dataset_encryption_cmek_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+dataset_encryption_cmek_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "key_name", concat("", [hint, ".", "key_name"])),
+		assertion.has_key(edata, "uses_default_key", concat("", [hint, ".", "uses_default_key"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		dataset_encryption_cmek_payload_assert_key_name(edata, "key_name", concat("", [hint, ".", "key_name"])),
+		dataset_encryption_cmek_payload_assert_uses_default_key(edata, "uses_default_key", concat("", [hint, ".", "uses_default_key"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+dataset_encryption_cmek_payload_assert_key_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+dataset_encryption_cmek_payload_assert_uses_default_key(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/googlecloud/bigquery/bigquery_table_encryption_cmek.gen.rego
+++ b/decision/googlecloud/bigquery/bigquery_table_encryption_cmek.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.bigquery
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure BigQuery datasets have default Customer-Managed Encryption Keys (CMEK)
 # You can emit this decision as follows:
@@ -35,6 +39,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_bigquery_table_encryption_cmek".
 table_encryption_cmek(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": table_encryption_cmek_header({
 			"allowed": d.allowed,
@@ -99,6 +104,31 @@ table_encryption_cmek_allowed(h) {
 #     "uses_default_key": false,
 #   }
 #   ```
-table_encryption_cmek_payload(edata) = x {
+table_encryption_cmek_payload(edata) := x {
+	table_encryption_cmek_payload_assert(edata, "<the argument to table_encryption_cmek_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+table_encryption_cmek_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "key_name", concat("", [hint, ".", "key_name"])),
+		assertion.has_key(edata, "uses_default_key", concat("", [hint, ".", "uses_default_key"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		table_encryption_cmek_payload_assert_key_name(edata, "key_name", concat("", [hint, ".", "key_name"])),
+		table_encryption_cmek_payload_assert_uses_default_key(edata, "uses_default_key", concat("", [hint, ".", "uses_default_key"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+table_encryption_cmek_payload_assert_key_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+table_encryption_cmek_payload_assert_uses_default_key(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/googlecloud/compute/compute_instance_confidential_computing.gen.rego
+++ b/decision/googlecloud/compute/compute_instance_confidential_computing.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.compute
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that Confidential VM for Compute Engine instances is enabled
 # You can emit this decision as follows:
@@ -35,6 +39,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_compute_instance_confidential_computing".
 instance_confidential_computing(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_confidential_computing_header({
 			"allowed": d.allowed,
@@ -99,9 +104,34 @@ instance_confidential_computing_allowed(h) {
 #     "machine_type": "example",
 #   }
 #   ```
-instance_confidential_computing_payload(edata) = x {
+instance_confidential_computing_payload(edata) := x {
+	instance_confidential_computing_payload_assert(edata, "<the argument to instance_confidential_computing_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_confidential_computing_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "confidential_computing_status", concat("", [hint, ".", "confidential_computing_status"])),
+		assertion.has_key(edata, "machine_type", concat("", [hint, ".", "machine_type"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		instance_confidential_computing_payload_assert_confidential_computing_status(edata, "confidential_computing_status", concat("", [hint, ".", "confidential_computing_status"])),
+		instance_confidential_computing_payload_assert_machine_type(edata, "machine_type", concat("", [hint, ".", "machine_type"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+instance_confidential_computing_payload_assert_confidential_computing_status(x, key, hint) {
+	assertion.is_type(x[key], "number", hint)
+} else := false
+
+instance_confidential_computing_payload_assert_machine_type(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
 
 CONFIDENTIAL_COMPUTING_STATUS_UNSUPPORTED = 0
 

--- a/decision/googlecloud/compute/compute_instance_oslogin.gen.rego
+++ b/decision/googlecloud/compute/compute_instance_oslogin.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.compute
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure OS Login is enabled for a project
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_compute_instance_oslogin".
 instance_oslogin(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_oslogin_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ instance_oslogin_allowed(h) {
 #     "oslogin_enabled": false,
 #   }
 #   ```
-instance_oslogin_payload(edata) = x {
+instance_oslogin_payload(edata) := x {
+	instance_oslogin_payload_assert(edata, "<the argument to instance_oslogin_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_oslogin_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "oslogin_enabled", concat("", [hint, ".", "oslogin_enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_oslogin_payload_assert_oslogin_enabled(edata, "oslogin_enabled", concat("", [hint, ".", "oslogin_enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_oslogin_payload_assert_oslogin_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/googlecloud/compute/compute_instance_project_wide_key_management.gen.rego
+++ b/decision/googlecloud/compute/compute_instance_project_wide_key_management.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.compute
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure Compute Engine instances block project-wide SSH keys
 # You can emit this decision as follows:
@@ -35,6 +39,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_compute_instance_project_wide_key_management".
 instance_project_wide_key_management(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_project_wide_key_management_header({
 			"allowed": d.allowed,
@@ -99,6 +104,31 @@ instance_project_wide_key_management_allowed(h) {
 #     "project_wide_key_available": false,
 #   }
 #   ```
-instance_project_wide_key_management_payload(edata) = x {
+instance_project_wide_key_management_payload(edata) := x {
+	instance_project_wide_key_management_payload_assert(edata, "<the argument to instance_project_wide_key_management_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_project_wide_key_management_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "blocked", concat("", [hint, ".", "blocked"])),
+		assertion.has_key(edata, "project_wide_key_available", concat("", [hint, ".", "project_wide_key_available"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		instance_project_wide_key_management_payload_assert_blocked(edata, "blocked", concat("", [hint, ".", "blocked"])),
+		instance_project_wide_key_management_payload_assert_project_wide_key_available(edata, "project_wide_key_available", concat("", [hint, ".", "project_wide_key_available"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+instance_project_wide_key_management_payload_assert_blocked(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false
+
+instance_project_wide_key_management_payload_assert_project_wide_key_available(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/googlecloud/compute/compute_instance_serial_port.gen.rego
+++ b/decision/googlecloud/compute/compute_instance_serial_port.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.compute
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure connections to serial ports are disabled for Compute Engine instances
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_compute_instance_serial_port".
 instance_serial_port(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_serial_port_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ instance_serial_port_allowed(h) {
 #     "serial_port_enabled": false,
 #   }
 #   ```
-instance_serial_port_payload(edata) = x {
+instance_serial_port_payload(edata) := x {
+	instance_serial_port_payload_assert(edata, "<the argument to instance_serial_port_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_serial_port_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "serial_port_enabled", concat("", [hint, ".", "serial_port_enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_serial_port_payload_assert_serial_port_enabled(edata, "serial_port_enabled", concat("", [hint, ".", "serial_port_enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_serial_port_payload_assert_serial_port_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/googlecloud/compute/compute_instance_shielded_vm.gen.rego
+++ b/decision/googlecloud/compute/compute_instance_shielded_vm.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.compute
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure Compute Engine instances enable Shielded VM features
 # You can emit this decision as follows:
@@ -36,6 +40,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_compute_instance_shielded_vm".
 instance_shielded_vm(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_shielded_vm_header({
 			"allowed": d.allowed,
@@ -102,6 +107,37 @@ instance_shielded_vm_allowed(h) {
 #     "vtpm_enabled": false,
 #   }
 #   ```
-instance_shielded_vm_payload(edata) = x {
+instance_shielded_vm_payload(edata) := x {
+	instance_shielded_vm_payload_assert(edata, "<the argument to instance_shielded_vm_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_shielded_vm_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "integrity_monitoring_enabled", concat("", [hint, ".", "integrity_monitoring_enabled"])),
+		assertion.has_key(edata, "secure_boot_enabled", concat("", [hint, ".", "secure_boot_enabled"])),
+		assertion.has_key(edata, "vtpm_enabled", concat("", [hint, ".", "vtpm_enabled"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		instance_shielded_vm_payload_assert_integrity_monitoring_enabled(edata, "integrity_monitoring_enabled", concat("", [hint, ".", "integrity_monitoring_enabled"])),
+		instance_shielded_vm_payload_assert_secure_boot_enabled(edata, "secure_boot_enabled", concat("", [hint, ".", "secure_boot_enabled"])),
+		instance_shielded_vm_payload_assert_vtpm_enabled(edata, "vtpm_enabled", concat("", [hint, ".", "vtpm_enabled"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+instance_shielded_vm_payload_assert_integrity_monitoring_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false
+
+instance_shielded_vm_payload_assert_secure_boot_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false
+
+instance_shielded_vm_payload_assert_vtpm_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/googlecloud/dns/dns_dnssec.gen.rego
+++ b/decision/googlecloud/dns/dns_dnssec.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.dns
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure DNSSEC is enabled for Cloud DNS zones
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_dns_dnssec".
 dnssec(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": dnssec_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ dnssec_allowed(h) {
 #     "dnssec_enabled": false,
 #   }
 #   ```
-dnssec_payload(edata) = x {
+dnssec_payload(edata) := x {
+	dnssec_payload_assert(edata, "<the argument to dnssec_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+dnssec_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "dnssec_enabled", concat("", [hint, ".", "dnssec_enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [dnssec_payload_assert_dnssec_enabled(edata, "dnssec_enabled", concat("", [hint, ".", "dnssec_enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+dnssec_payload_assert_dnssec_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/googlecloud/dns/dns_dnssec_ksk_algorithm.gen.rego
+++ b/decision/googlecloud/dns/dns_dnssec_ksk_algorithm.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.dns
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure the Key-Signing Key in Cloud DNS uses a secure algorithm
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_dns_dnssec_ksk_algorithm".
 dnssec_ksk_algorithm(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": dnssec_ksk_algorithm_header({
 			"allowed": d.allowed,
@@ -96,6 +101,34 @@ dnssec_ksk_algorithm_allowed(h) {
 #     "algorithms": ["example"],
 #   }
 #   ```
-dnssec_ksk_algorithm_payload(edata) = x {
+dnssec_ksk_algorithm_payload(edata) := x {
+	dnssec_ksk_algorithm_payload_assert(edata, "<the argument to dnssec_ksk_algorithm_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+dnssec_ksk_algorithm_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "algorithms", concat("", [hint, ".", "algorithms"]))]
+	every c in key_checks { c }
+
+	value_checks := [dnssec_ksk_algorithm_payload_assert_algorithms(edata, "algorithms", concat("", [hint, ".", "algorithms"]))]
+	every c in value_checks { c }
+} else := false
+
+dnssec_ksk_algorithm_payload_assert_algorithms(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [dnssec_ksk_algorithm_payload_assert_algorithms_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+dnssec_ksk_algorithm_payload_assert_algorithms_element(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/dns/dns_dnssec_zsk_algorithm.gen.rego
+++ b/decision/googlecloud/dns/dns_dnssec_zsk_algorithm.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.dns
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure the Zone-Signing Key in Cloud DNS uses a secure algorithm
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_dns_dnssec_zsk_algorithm".
 dnssec_zsk_algorithm(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": dnssec_zsk_algorithm_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ dnssec_zsk_algorithm_allowed(h) {
 #     "algorithm": "example",
 #   }
 #   ```
-dnssec_zsk_algorithm_payload(edata) = x {
+dnssec_zsk_algorithm_payload(edata) := x {
+	dnssec_zsk_algorithm_payload_assert(edata, "<the argument to dnssec_zsk_algorithm_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+dnssec_zsk_algorithm_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "algorithm", concat("", [hint, ".", "algorithm"]))]
+	every c in key_checks { c }
+
+	value_checks := [dnssec_zsk_algorithm_payload_assert_algorithm(edata, "algorithm", concat("", [hint, ".", "algorithm"]))]
+	every c in value_checks { c }
+} else := false
+
+dnssec_zsk_algorithm_payload_assert_algorithm(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/iam/iam_service_account_admin_separation.gen.rego
+++ b/decision/googlecloud/iam/iam_service_account_admin_separation.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.iam
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that separation of duties is enforced for administration and usage of service accounts
 # You can emit this decision as follows:
@@ -35,6 +39,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_iam_service_account_admin_separation".
 service_account_admin_separation(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": service_account_admin_separation_header({
 			"allowed": d.allowed,
@@ -99,6 +104,75 @@ service_account_admin_separation_allowed(h) {
 #     "users": [{"principal": "example", "role": "example"}],
 #   }
 #   ```
-service_account_admin_separation_payload(edata) = x {
+service_account_admin_separation_payload(edata) := x {
+	service_account_admin_separation_payload_assert(edata, "<the argument to service_account_admin_separation_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+service_account_admin_separation_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "admin_principals", concat("", [hint, ".", "admin_principals"])),
+		assertion.has_key(edata, "users", concat("", [hint, ".", "users"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		service_account_admin_separation_payload_assert_admin_principals(edata, "admin_principals", concat("", [hint, ".", "admin_principals"])),
+		service_account_admin_separation_payload_assert_users(edata, "users", concat("", [hint, ".", "users"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+service_account_admin_separation_payload_assert_admin_principals(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [service_account_admin_separation_payload_assert_admin_principals_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+service_account_admin_separation_payload_assert_admin_principals_element(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+service_account_admin_separation_payload_assert_users(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [service_account_admin_separation_payload_assert_users_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+service_account_admin_separation_payload_assert_users_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "principal", "string", hint),
+		assertion.has_typed_key(x[key], "role", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		service_account_admin_separation_payload_assert_users_element_principal(x[key], "principal", concat("", [hint, ".", "principal"])),
+		service_account_admin_separation_payload_assert_users_element_role(x[key], "role", concat("", [hint, ".", "role"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+service_account_admin_separation_payload_assert_users_element_principal(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+service_account_admin_separation_payload_assert_users_element_role(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/iam/iam_service_account_project_admin_role.gen.rego
+++ b/decision/googlecloud/iam/iam_service_account_project_admin_role.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.iam
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure Google Cloud service accounts have admin privileges only when truly required
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_iam_service_account_project_admin_role".
 service_account_project_admin_role(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": service_account_project_admin_role_header({
 			"allowed": d.allowed,
@@ -96,6 +101,52 @@ service_account_project_admin_role_allowed(h) {
 #     "suspicious_bindings": [{"service_account_email": "example", "role": "example"}],
 #   }
 #   ```
-service_account_project_admin_role_payload(edata) = x {
+service_account_project_admin_role_payload(edata) := x {
+	service_account_project_admin_role_payload_assert(edata, "<the argument to service_account_project_admin_role_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+service_account_project_admin_role_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "suspicious_bindings", concat("", [hint, ".", "suspicious_bindings"]))]
+	every c in key_checks { c }
+
+	value_checks := [service_account_project_admin_role_payload_assert_suspicious_bindings(edata, "suspicious_bindings", concat("", [hint, ".", "suspicious_bindings"]))]
+	every c in value_checks { c }
+} else := false
+
+service_account_project_admin_role_payload_assert_suspicious_bindings(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [service_account_project_admin_role_payload_assert_suspicious_bindings_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+service_account_project_admin_role_payload_assert_suspicious_bindings_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "service_account_email", "string", hint),
+		assertion.has_typed_key(x[key], "role", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		service_account_project_admin_role_payload_assert_suspicious_bindings_element_service_account_email(x[key], "service_account_email", concat("", [hint, ".", "service_account_email"])),
+		service_account_project_admin_role_payload_assert_suspicious_bindings_element_role(x[key], "role", concat("", [hint, ".", "role"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+service_account_project_admin_role_payload_assert_suspicious_bindings_element_role(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+service_account_project_admin_role_payload_assert_suspicious_bindings_element_service_account_email(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/iam/iam_service_account_project_impersonation_role.gen.rego
+++ b/decision/googlecloud/iam/iam_service_account_project_impersonation_role.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.iam
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure a Cloud IAM principal can impersonate or attach only a limited set of service accounts
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_iam_service_account_project_impersonation_role".
 service_account_project_impersonation_role(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": service_account_project_impersonation_role_header({
 			"allowed": d.allowed,
@@ -96,6 +101,34 @@ service_account_project_impersonation_role_allowed(h) {
 #     "permissive_principals": ["example"],
 #   }
 #   ```
-service_account_project_impersonation_role_payload(edata) = x {
+service_account_project_impersonation_role_payload(edata) := x {
+	service_account_project_impersonation_role_payload_assert(edata, "<the argument to service_account_project_impersonation_role_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+service_account_project_impersonation_role_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "permissive_principals", concat("", [hint, ".", "permissive_principals"]))]
+	every c in key_checks { c }
+
+	value_checks := [service_account_project_impersonation_role_payload_assert_permissive_principals(edata, "permissive_principals", concat("", [hint, ".", "permissive_principals"]))]
+	every c in value_checks { c }
+} else := false
+
+service_account_project_impersonation_role_payload_assert_permissive_principals(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [service_account_project_impersonation_role_payload_assert_permissive_principals_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+service_account_project_impersonation_role_payload_assert_permissive_principals_element(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/kms/kms_admin_separation.gen.rego
+++ b/decision/googlecloud/kms/kms_admin_separation.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.kms
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that separation of duties is enforced for administration and usage of Cloud KMS
 # You can emit this decision as follows:
@@ -35,6 +39,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_kms_admin_separation".
 admin_separation(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": admin_separation_header({
 			"allowed": d.allowed,
@@ -99,6 +104,75 @@ admin_separation_allowed(h) {
 #     "users": [{"principal": "example", "role": "example"}],
 #   }
 #   ```
-admin_separation_payload(edata) = x {
+admin_separation_payload(edata) := x {
+	admin_separation_payload_assert(edata, "<the argument to admin_separation_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+admin_separation_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "admin_principals", concat("", [hint, ".", "admin_principals"])),
+		assertion.has_key(edata, "users", concat("", [hint, ".", "users"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		admin_separation_payload_assert_admin_principals(edata, "admin_principals", concat("", [hint, ".", "admin_principals"])),
+		admin_separation_payload_assert_users(edata, "users", concat("", [hint, ".", "users"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+admin_separation_payload_assert_admin_principals(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [admin_separation_payload_assert_admin_principals_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+admin_separation_payload_assert_admin_principals_element(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+admin_separation_payload_assert_users(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [admin_separation_payload_assert_users_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+admin_separation_payload_assert_users_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "principal", "string", hint),
+		assertion.has_typed_key(x[key], "role", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		admin_separation_payload_assert_users_element_principal(x[key], "principal", concat("", [hint, ".", "principal"])),
+		admin_separation_payload_assert_users_element_role(x[key], "role", concat("", [hint, ".", "role"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+admin_separation_payload_assert_users_element_principal(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+admin_separation_payload_assert_users_element_role(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/logging/logging_api_audit.gen.rego
+++ b/decision/googlecloud/logging/logging_api_audit.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.logging
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure Cloud Audit Logging is configured to record API operations
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_logging_api_audit".
 api_audit(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": api_audit_header({
 			"allowed": d.allowed,
@@ -96,9 +101,99 @@ api_audit_allowed(h) {
 #     "audit_configs": [{"service": "example", "audit_log_configs": [{"audit_log_config_log_type": AUDIT_LOG_CONFIG_LOG_TYPE_LOG_TYPE_UNSPECIFIED, "exempted_members": ["example"]}]}],
 #   }
 #   ```
-api_audit_payload(edata) = x {
+api_audit_payload(edata) := x {
+	api_audit_payload_assert(edata, "<the argument to api_audit_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+api_audit_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "audit_configs", concat("", [hint, ".", "audit_configs"]))]
+	every c in key_checks { c }
+
+	value_checks := [api_audit_payload_assert_audit_configs(edata, "audit_configs", concat("", [hint, ".", "audit_configs"]))]
+	every c in value_checks { c }
+} else := false
+
+api_audit_payload_assert_audit_configs(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [api_audit_payload_assert_audit_configs_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+api_audit_payload_assert_audit_configs_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "service", "string", hint),
+		assertion.has_typed_key(x[key], "audit_log_configs", "array", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		api_audit_payload_assert_audit_configs_element_service(x[key], "service", concat("", [hint, ".", "service"])),
+		api_audit_payload_assert_audit_configs_element_audit_log_configs(x[key], "audit_log_configs", concat("", [hint, ".", "audit_log_configs"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+api_audit_payload_assert_audit_configs_element_audit_log_configs(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [api_audit_payload_assert_audit_configs_element_audit_log_configs_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+api_audit_payload_assert_audit_configs_element_audit_log_configs_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "audit_log_config_log_type", "number", hint),
+		assertion.has_typed_key(x[key], "exempted_members", "array", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		api_audit_payload_assert_audit_configs_element_audit_log_configs_element_audit_log_config_log_type(x[key], "audit_log_config_log_type", concat("", [hint, ".", "audit_log_config_log_type"])),
+		api_audit_payload_assert_audit_configs_element_audit_log_configs_element_exempted_members(x[key], "exempted_members", concat("", [hint, ".", "exempted_members"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+api_audit_payload_assert_audit_configs_element_audit_log_configs_element_audit_log_config_log_type(x, key, hint) {
+	assertion.is_type(x[key], "number", hint)
+} else := false
+
+api_audit_payload_assert_audit_configs_element_audit_log_configs_element_exempted_members(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [api_audit_payload_assert_audit_configs_element_audit_log_configs_element_exempted_members_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+api_audit_payload_assert_audit_configs_element_audit_log_configs_element_exempted_members_element(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+api_audit_payload_assert_audit_configs_element_service(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
 
 AUDIT_LOG_CONFIG_LOG_TYPE_LOG_TYPE_UNSPECIFIED = 0
 

--- a/decision/googlecloud/logmetric/logmetric_audit_config_changes.gen.rego
+++ b/decision/googlecloud/logmetric/logmetric_audit_config_changes.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that the log metric filter and alerts exist for audit configuration changes
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_logmetric_audit_config_changes".
 audit_config_changes(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": audit_config_changes_header({
 			"allowed": d.allowed,
@@ -96,6 +101,52 @@ audit_config_changes_allowed(h) {
 #     "cis_notification_implementations": [{"metric_name": "example", "alert_policy_name": "example"}],
 #   }
 #   ```
-audit_config_changes_payload(edata) = x {
+audit_config_changes_payload(edata) := x {
+	audit_config_changes_payload_assert(edata, "<the argument to audit_config_changes_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+audit_config_changes_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [audit_config_changes_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+audit_config_changes_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [audit_config_changes_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+audit_config_changes_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "alert_policy_name", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		audit_config_changes_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		audit_config_changes_payload_assert_cis_notification_implementations_element_alert_policy_name(x[key], "alert_policy_name", concat("", [hint, ".", "alert_policy_name"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+audit_config_changes_payload_assert_cis_notification_implementations_element_alert_policy_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+audit_config_changes_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/logmetric/logmetric_custom_role_changes.gen.rego
+++ b/decision/googlecloud/logmetric/logmetric_custom_role_changes.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that the log metric filter and alerts exist for custom role changes
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_logmetric_custom_role_changes".
 custom_role_changes(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": custom_role_changes_header({
 			"allowed": d.allowed,
@@ -96,6 +101,52 @@ custom_role_changes_allowed(h) {
 #     "cis_notification_implementations": [{"metric_name": "example", "alert_policy_name": "example"}],
 #   }
 #   ```
-custom_role_changes_payload(edata) = x {
+custom_role_changes_payload(edata) := x {
+	custom_role_changes_payload_assert(edata, "<the argument to custom_role_changes_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+custom_role_changes_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [custom_role_changes_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+custom_role_changes_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [custom_role_changes_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+custom_role_changes_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "alert_policy_name", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		custom_role_changes_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		custom_role_changes_payload_assert_cis_notification_implementations_element_alert_policy_name(x[key], "alert_policy_name", concat("", [hint, ".", "alert_policy_name"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+custom_role_changes_payload_assert_cis_notification_implementations_element_alert_policy_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+custom_role_changes_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/logmetric/logmetric_firewall_rule_changes.gen.rego
+++ b/decision/googlecloud/logmetric/logmetric_firewall_rule_changes.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that the log metric filter and alerts exist for VPC network firewall rule changes
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_logmetric_firewall_rule_changes".
 firewall_rule_changes(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": firewall_rule_changes_header({
 			"allowed": d.allowed,
@@ -96,6 +101,52 @@ firewall_rule_changes_allowed(h) {
 #     "cis_notification_implementations": [{"metric_name": "example", "alert_policy_name": "example"}],
 #   }
 #   ```
-firewall_rule_changes_payload(edata) = x {
+firewall_rule_changes_payload(edata) := x {
+	firewall_rule_changes_payload_assert(edata, "<the argument to firewall_rule_changes_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+firewall_rule_changes_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [firewall_rule_changes_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+firewall_rule_changes_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [firewall_rule_changes_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+firewall_rule_changes_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "alert_policy_name", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		firewall_rule_changes_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		firewall_rule_changes_payload_assert_cis_notification_implementations_element_alert_policy_name(x[key], "alert_policy_name", concat("", [hint, ".", "alert_policy_name"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+firewall_rule_changes_payload_assert_cis_notification_implementations_element_alert_policy_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+firewall_rule_changes_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/logmetric/logmetric_network_route_changes.gen.rego
+++ b/decision/googlecloud/logmetric/logmetric_network_route_changes.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that the log metric filter and alerts exist for VPC network route changes
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_logmetric_network_route_changes".
 network_route_changes(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": network_route_changes_header({
 			"allowed": d.allowed,
@@ -96,6 +101,52 @@ network_route_changes_allowed(h) {
 #     "cis_notification_implementations": [{"metric_name": "example", "alert_policy_name": "example"}],
 #   }
 #   ```
-network_route_changes_payload(edata) = x {
+network_route_changes_payload(edata) := x {
+	network_route_changes_payload_assert(edata, "<the argument to network_route_changes_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+network_route_changes_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [network_route_changes_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+network_route_changes_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [network_route_changes_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+network_route_changes_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "alert_policy_name", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		network_route_changes_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		network_route_changes_payload_assert_cis_notification_implementations_element_alert_policy_name(x[key], "alert_policy_name", concat("", [hint, ".", "alert_policy_name"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+network_route_changes_payload_assert_cis_notification_implementations_element_alert_policy_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+network_route_changes_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/logmetric/logmetric_project_ownership_changes.gen.rego
+++ b/decision/googlecloud/logmetric/logmetric_project_ownership_changes.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that the log metric filter and alerts exist for project ownership assignments/changes
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_logmetric_project_ownership_changes".
 project_ownership_changes(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": project_ownership_changes_header({
 			"allowed": d.allowed,
@@ -96,6 +101,52 @@ project_ownership_changes_allowed(h) {
 #     "cis_notification_implementations": [{"metric_name": "example", "alert_policy_name": "example"}],
 #   }
 #   ```
-project_ownership_changes_payload(edata) = x {
+project_ownership_changes_payload(edata) := x {
+	project_ownership_changes_payload_assert(edata, "<the argument to project_ownership_changes_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+project_ownership_changes_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [project_ownership_changes_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+project_ownership_changes_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [project_ownership_changes_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+project_ownership_changes_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "alert_policy_name", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		project_ownership_changes_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		project_ownership_changes_payload_assert_cis_notification_implementations_element_alert_policy_name(x[key], "alert_policy_name", concat("", [hint, ".", "alert_policy_name"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+project_ownership_changes_payload_assert_cis_notification_implementations_element_alert_policy_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+project_ownership_changes_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/logmetric/logmetric_sql_config_changes.gen.rego
+++ b/decision/googlecloud/logmetric/logmetric_sql_config_changes.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that the log metric filter and alerts exist for SQL instance configuration changes
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_logmetric_sql_config_changes".
 sql_config_changes(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": sql_config_changes_header({
 			"allowed": d.allowed,
@@ -96,6 +101,52 @@ sql_config_changes_allowed(h) {
 #     "cis_notification_implementations": [{"metric_name": "example", "alert_policy_name": "example"}],
 #   }
 #   ```
-sql_config_changes_payload(edata) = x {
+sql_config_changes_payload(edata) := x {
+	sql_config_changes_payload_assert(edata, "<the argument to sql_config_changes_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+sql_config_changes_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [sql_config_changes_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+sql_config_changes_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [sql_config_changes_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+sql_config_changes_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "alert_policy_name", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		sql_config_changes_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		sql_config_changes_payload_assert_cis_notification_implementations_element_alert_policy_name(x[key], "alert_policy_name", concat("", [hint, ".", "alert_policy_name"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+sql_config_changes_payload_assert_cis_notification_implementations_element_alert_policy_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+sql_config_changes_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/logmetric/logmetric_storage_iam_changes.gen.rego
+++ b/decision/googlecloud/logmetric/logmetric_storage_iam_changes.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that the log metric filter and alerts exist for Cloud Storage IAM permission changes
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_logmetric_storage_iam_changes".
 storage_iam_changes(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": storage_iam_changes_header({
 			"allowed": d.allowed,
@@ -96,6 +101,52 @@ storage_iam_changes_allowed(h) {
 #     "cis_notification_implementations": [{"metric_name": "example", "alert_policy_name": "example"}],
 #   }
 #   ```
-storage_iam_changes_payload(edata) = x {
+storage_iam_changes_payload(edata) := x {
+	storage_iam_changes_payload_assert(edata, "<the argument to storage_iam_changes_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+storage_iam_changes_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [storage_iam_changes_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+storage_iam_changes_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [storage_iam_changes_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+storage_iam_changes_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "alert_policy_name", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		storage_iam_changes_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		storage_iam_changes_payload_assert_cis_notification_implementations_element_alert_policy_name(x[key], "alert_policy_name", concat("", [hint, ".", "alert_policy_name"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+storage_iam_changes_payload_assert_cis_notification_implementations_element_alert_policy_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+storage_iam_changes_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/logmetric/logmetric_vpc_network_changes.gen.rego
+++ b/decision/googlecloud/logmetric/logmetric_vpc_network_changes.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.logmetric
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that the log metric filter and alerts exist for VPC network changes
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_logmetric_vpc_network_changes".
 vpc_network_changes(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": vpc_network_changes_header({
 			"allowed": d.allowed,
@@ -96,6 +101,52 @@ vpc_network_changes_allowed(h) {
 #     "cis_notification_implementations": [{"metric_name": "example", "alert_policy_name": "example"}],
 #   }
 #   ```
-vpc_network_changes_payload(edata) = x {
+vpc_network_changes_payload(edata) := x {
+	vpc_network_changes_payload_assert(edata, "<the argument to vpc_network_changes_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+vpc_network_changes_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in key_checks { c }
+
+	value_checks := [vpc_network_changes_payload_assert_cis_notification_implementations(edata, "cis_notification_implementations", concat("", [hint, ".", "cis_notification_implementations"]))]
+	every c in value_checks { c }
+} else := false
+
+vpc_network_changes_payload_assert_cis_notification_implementations(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [vpc_network_changes_payload_assert_cis_notification_implementations_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+vpc_network_changes_payload_assert_cis_notification_implementations_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "metric_name", "string", hint),
+		assertion.has_typed_key(x[key], "alert_policy_name", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		vpc_network_changes_payload_assert_cis_notification_implementations_element_metric_name(x[key], "metric_name", concat("", [hint, ".", "metric_name"])),
+		vpc_network_changes_payload_assert_cis_notification_implementations_element_alert_policy_name(x[key], "alert_policy_name", concat("", [hint, ".", "alert_policy_name"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+vpc_network_changes_payload_assert_cis_notification_implementations_element_alert_policy_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+vpc_network_changes_payload_assert_cis_notification_implementations_element_metric_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/networking/networking_default_network.gen.rego
+++ b/decision/googlecloud/networking/networking_default_network.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.networking
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure the default network does not exist in Google Cloud projects
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_networking_default_network".
 default_network(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": default_network_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ default_network_allowed(h) {
 #     "default_network_exists": false,
 #   }
 #   ```
-default_network_payload(edata) = x {
+default_network_payload(edata) := x {
+	default_network_payload_assert(edata, "<the argument to default_network_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+default_network_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "default_network_exists", concat("", [hint, ".", "default_network_exists"]))]
+	every c in key_checks { c }
+
+	value_checks := [default_network_payload_assert_default_network_exists(edata, "default_network_exists", concat("", [hint, ".", "default_network_exists"]))]
+	every c in value_checks { c }
+} else := false
+
+default_network_payload_assert_default_network_exists(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/googlecloud/networking/networking_dns_log.gen.rego
+++ b/decision/googlecloud/networking/networking_dns_log.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.networking
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure Cloud DNS Logging is enabled for all VPC networks
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_networking_dns_log".
 dns_log(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": dns_log_header({
 			"allowed": d.allowed,
@@ -97,6 +102,21 @@ dns_log_allowed(h) {
 #     "log_enabled": false,
 #   }
 #   ```
-dns_log_payload(edata) = x {
+dns_log_payload(edata) := x {
+	dns_log_payload_assert(edata, "<the argument to dns_log_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+dns_log_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "log_enabled", concat("", [hint, ".", "log_enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [dns_log_payload_assert_log_enabled(edata, "log_enabled", concat("", [hint, ".", "log_enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+dns_log_payload_assert_log_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/googlecloud/networking/networking_fw_rule_iap.gen.rego
+++ b/decision/googlecloud/networking/networking_fw_rule_iap.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.networking
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that VPC networks allow only traffic from Google IP addresses with Identity Aware Proxy (IAP)
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_networking_fw_rule_iap".
 fw_rule_iap(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": fw_rule_iap_header({
 			"allowed": d.allowed,
@@ -96,6 +101,133 @@ fw_rule_iap_allowed(h) {
 #     "ingress_rules": [{"name": "example", "source_ranges": ["example"], "allow_rules": [{"ip_protocol": "example", "port_ranges": [{"from": 0, "to": 0}]}]}],
 #   }
 #   ```
-fw_rule_iap_payload(edata) = x {
+fw_rule_iap_payload(edata) := x {
+	fw_rule_iap_payload_assert(edata, "<the argument to fw_rule_iap_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+fw_rule_iap_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "ingress_rules", concat("", [hint, ".", "ingress_rules"]))]
+	every c in key_checks { c }
+
+	value_checks := [fw_rule_iap_payload_assert_ingress_rules(edata, "ingress_rules", concat("", [hint, ".", "ingress_rules"]))]
+	every c in value_checks { c }
+} else := false
+
+fw_rule_iap_payload_assert_ingress_rules(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [fw_rule_iap_payload_assert_ingress_rules_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+fw_rule_iap_payload_assert_ingress_rules_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "name", "string", hint),
+		assertion.has_typed_key(x[key], "source_ranges", "array", hint),
+		assertion.has_typed_key(x[key], "allow_rules", "array", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		fw_rule_iap_payload_assert_ingress_rules_element_name(x[key], "name", concat("", [hint, ".", "name"])),
+		fw_rule_iap_payload_assert_ingress_rules_element_source_ranges(x[key], "source_ranges", concat("", [hint, ".", "source_ranges"])),
+		fw_rule_iap_payload_assert_ingress_rules_element_allow_rules(x[key], "allow_rules", concat("", [hint, ".", "allow_rules"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+fw_rule_iap_payload_assert_ingress_rules_element_allow_rules(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [fw_rule_iap_payload_assert_ingress_rules_element_allow_rules_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+fw_rule_iap_payload_assert_ingress_rules_element_allow_rules_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "ip_protocol", "string", hint),
+		assertion.has_typed_key(x[key], "port_ranges", "array", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		fw_rule_iap_payload_assert_ingress_rules_element_allow_rules_element_ip_protocol(x[key], "ip_protocol", concat("", [hint, ".", "ip_protocol"])),
+		fw_rule_iap_payload_assert_ingress_rules_element_allow_rules_element_port_ranges(x[key], "port_ranges", concat("", [hint, ".", "port_ranges"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+fw_rule_iap_payload_assert_ingress_rules_element_allow_rules_element_ip_protocol(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+fw_rule_iap_payload_assert_ingress_rules_element_allow_rules_element_port_ranges(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [fw_rule_iap_payload_assert_ingress_rules_element_allow_rules_element_port_ranges_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+fw_rule_iap_payload_assert_ingress_rules_element_allow_rules_element_port_ranges_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "from", "number", hint),
+		assertion.has_typed_key(x[key], "to", "number", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		fw_rule_iap_payload_assert_ingress_rules_element_allow_rules_element_port_ranges_element_from(x[key], "from", concat("", [hint, ".", "from"])),
+		fw_rule_iap_payload_assert_ingress_rules_element_allow_rules_element_port_ranges_element_to(x[key], "to", concat("", [hint, ".", "to"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+fw_rule_iap_payload_assert_ingress_rules_element_allow_rules_element_port_ranges_element_from(x, key, hint) {
+	assertion.is_type(x[key], "number", hint)
+} else := false
+
+fw_rule_iap_payload_assert_ingress_rules_element_allow_rules_element_port_ranges_element_to(x, key, hint) {
+	assertion.is_type(x[key], "number", hint)
+} else := false
+
+fw_rule_iap_payload_assert_ingress_rules_element_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+fw_rule_iap_payload_assert_ingress_rules_element_source_ranges(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [fw_rule_iap_payload_assert_ingress_rules_element_source_ranges_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+fw_rule_iap_payload_assert_ingress_rules_element_source_ranges_element(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/networking/networking_legacy_network.gen.rego
+++ b/decision/googlecloud/networking/networking_legacy_network.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.networking
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure legacy networks do not exist for older Google Cloud projects
 # You can emit this decision as follows:
@@ -35,6 +39,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_networking_legacy_network".
 legacy_network(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": legacy_network_header({
 			"allowed": d.allowed,
@@ -99,6 +104,31 @@ legacy_network_allowed(h) {
 #     "subnetwork_mode": "example",
 #   }
 #   ```
-legacy_network_payload(edata) = x {
+legacy_network_payload(edata) := x {
+	legacy_network_payload_assert(edata, "<the argument to legacy_network_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+legacy_network_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "name", concat("", [hint, ".", "name"])),
+		assertion.has_key(edata, "subnetwork_mode", concat("", [hint, ".", "subnetwork_mode"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		legacy_network_payload_assert_name(edata, "name", concat("", [hint, ".", "name"])),
+		legacy_network_payload_assert_subnetwork_mode(edata, "subnetwork_mode", concat("", [hint, ".", "subnetwork_mode"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+legacy_network_payload_assert_name(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+legacy_network_payload_assert_subnetwork_mode(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/networking/networking_proxy_tls_policy.gen.rego
+++ b/decision/googlecloud/networking/networking_proxy_tls_policy.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.networking
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that Cloud Load Balancing uses TLS policies with strong cipher suites
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_networking_proxy_tls_policy".
 proxy_tls_policy(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": proxy_tls_policy_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ proxy_tls_policy_allowed(h) {
 #     "tls_policy_attached": false,
 #   }
 #   ```
-proxy_tls_policy_payload(edata) = x {
+proxy_tls_policy_payload(edata) := x {
+	proxy_tls_policy_payload_assert(edata, "<the argument to proxy_tls_policy_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+proxy_tls_policy_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "tls_policy_attached", concat("", [hint, ".", "tls_policy_attached"]))]
+	every c in key_checks { c }
+
+	value_checks := [proxy_tls_policy_payload_assert_tls_policy_attached(edata, "tls_policy_attached", concat("", [hint, ".", "tls_policy_attached"]))]
+	every c in value_checks { c }
+} else := false
+
+proxy_tls_policy_payload_assert_tls_policy_attached(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/googlecloud/networking/networking_ssh_access.gen.rego
+++ b/decision/googlecloud/networking/networking_ssh_access.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.networking
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure SSH access to Google Cloud resources is restricted from the Internet
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_networking_ssh_access".
 ssh_access(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": ssh_access_header({
 			"allowed": d.allowed,
@@ -97,6 +102,42 @@ ssh_access_allowed(h) {
 #     "exposed_surfaces": [{"network_self_link": "example"}],
 #   }
 #   ```
-ssh_access_payload(edata) = x {
+ssh_access_payload(edata) := x {
+	ssh_access_payload_assert(edata, "<the argument to ssh_access_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+ssh_access_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "exposed_surfaces", concat("", [hint, ".", "exposed_surfaces"]))]
+	every c in key_checks { c }
+
+	value_checks := [ssh_access_payload_assert_exposed_surfaces(edata, "exposed_surfaces", concat("", [hint, ".", "exposed_surfaces"]))]
+	every c in value_checks { c }
+} else := false
+
+ssh_access_payload_assert_exposed_surfaces(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [ssh_access_payload_assert_exposed_surfaces_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+ssh_access_payload_assert_exposed_surfaces_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [assertion.has_typed_key(x[key], "network_self_link", "string", hint)]
+	every c in key_checks { c }
+	value_checks := [ssh_access_payload_assert_exposed_surfaces_element_network_self_link(x[key], "network_self_link", concat("", [hint, ".", "network_self_link"]))]
+	every c in value_checks { c }
+} else := false
+
+ssh_access_payload_assert_exposed_surfaces_element_network_self_link(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/networking/networking_vpc_flow_log.gen.rego
+++ b/decision/googlecloud/networking/networking_vpc_flow_log.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.networking
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure VPC Flow Logs feature is enabled for critical VPC networks and subnets
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_networking_vpc_flow_log".
 vpc_flow_log(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": vpc_flow_log_header({
 			"allowed": d.allowed,
@@ -97,6 +102,21 @@ vpc_flow_log_allowed(h) {
 #     "flow_log_enabled": false,
 #   }
 #   ```
-vpc_flow_log_payload(edata) = x {
+vpc_flow_log_payload(edata) := x {
+	vpc_flow_log_payload_assert(edata, "<the argument to vpc_flow_log_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+vpc_flow_log_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "flow_log_enabled", concat("", [hint, ".", "flow_log_enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [vpc_flow_log_payload_assert_flow_log_enabled(edata, "flow_log_enabled", concat("", [hint, ".", "flow_log_enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+vpc_flow_log_payload_assert_flow_log_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/googlecloud/sql/sql_instance_backup.gen.rego
+++ b/decision/googlecloud/sql/sql_instance_backup.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.sql
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure Cloud SQL instances use automatic backups
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_sql_instance_backup".
 instance_backup(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_backup_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ instance_backup_allowed(h) {
 #     "auto_backup_enabled": false,
 #   }
 #   ```
-instance_backup_payload(edata) = x {
+instance_backup_payload(edata) := x {
+	instance_backup_payload_assert(edata, "<the argument to instance_backup_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_backup_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "auto_backup_enabled", concat("", [hint, ".", "auto_backup_enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_backup_payload_assert_auto_backup_enabled(edata, "auto_backup_enabled", concat("", [hint, ".", "auto_backup_enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_backup_payload_assert_auto_backup_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/googlecloud/sql/sql_instance_connection.gen.rego
+++ b/decision/googlecloud/sql/sql_instance_connection.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.sql
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure Cloud SQL instances require TLS for all incoming connections
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_sql_instance_connection".
 instance_connection(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_connection_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ instance_connection_allowed(h) {
 #     "tls_required": false,
 #   }
 #   ```
-instance_connection_payload(edata) = x {
+instance_connection_payload(edata) := x {
+	instance_connection_payload_assert(edata, "<the argument to instance_connection_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_connection_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "tls_required", concat("", [hint, ".", "tls_required"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_connection_payload_assert_tls_required(edata, "tls_required", concat("", [hint, ".", "tls_required"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_connection_payload_assert_tls_required(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/googlecloud/sql/sql_instance_mysql_local_infile.gen.rego
+++ b/decision/googlecloud/sql/sql_instance_mysql_local_infile.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.sql
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that the local_infile database flag for a Cloud SQL for MySQL instance is set to off
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_sql_instance_mysql_local_infile".
 instance_mysql_local_infile(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_mysql_local_infile_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ instance_mysql_local_infile_allowed(h) {
 #     "local_infile_state": "example",
 #   }
 #   ```
-instance_mysql_local_infile_payload(edata) = x {
+instance_mysql_local_infile_payload(edata) := x {
+	instance_mysql_local_infile_payload_assert(edata, "<the argument to instance_mysql_local_infile_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_mysql_local_infile_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "local_infile_state", concat("", [hint, ".", "local_infile_state"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_mysql_local_infile_payload_assert_local_infile_state(edata, "local_infile_state", concat("", [hint, ".", "local_infile_state"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_mysql_local_infile_payload_assert_local_infile_state(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/sql/sql_instance_mysql_show_database.gen.rego
+++ b/decision/googlecloud/sql/sql_instance_mysql_show_database.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.sql
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that the skip_show_database database flag for Cloud SQL for MySQL instance is set to on
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_sql_instance_mysql_show_database".
 instance_mysql_show_database(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_mysql_show_database_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ instance_mysql_show_database_allowed(h) {
 #     "skip_show_database_state": "example",
 #   }
 #   ```
-instance_mysql_show_database_payload(edata) = x {
+instance_mysql_show_database_payload(edata) := x {
+	instance_mysql_show_database_payload_assert(edata, "<the argument to instance_mysql_show_database_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_mysql_show_database_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "skip_show_database_state", concat("", [hint, ".", "skip_show_database_state"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_mysql_show_database_payload_assert_skip_show_database_state(edata, "skip_show_database_state", concat("", [hint, ".", "skip_show_database_state"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_mysql_show_database_payload_assert_skip_show_database_state(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/sql/sql_instance_postgresql_centralized_logging.gen.rego
+++ b/decision/googlecloud/sql/sql_instance_postgresql_centralized_logging.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.sql
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that cloudsql.enable_pgaudit database flag for each Cloud SQL for PostgreSQL instance is set to on for centralized logging
 # You can emit this decision as follows:
@@ -22,7 +26,7 @@ import data.shisho
 #     "allowed": allowed,
 #     "subject": subject,
 #     "payload": shisho.decision.googlecloud.sql.instance_postgresql_centralized_logging_payload({
-#       "pgaudit_enabled": false,
+#       "pgaudit_enabled": "example",
 #     }),
 #   })
 # }
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_sql_instance_postgresql_centralized_logging".
 instance_postgresql_centralized_logging(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_postgresql_centralized_logging_header({
 			"allowed": d.allowed,
@@ -88,14 +93,29 @@ instance_postgresql_centralized_logging_allowed(h) {
 #   Emits a decision entry describing the detail of a decision decision.api.shisho.dev/v1beta:googlecloud_sql_instance_postgresql_centralized_logging
 #
 #   The parameter `data` is an object with the following fields: 
-#   - pgaudit_enabled: boolean
+#   - pgaudit_enabled: string
 #
 #   For instance, `data` can take the following value:
 #   ```rego
 #   {
-#     "pgaudit_enabled": false,
+#     "pgaudit_enabled": "example",
 #   }
 #   ```
-instance_postgresql_centralized_logging_payload(edata) = x {
+instance_postgresql_centralized_logging_payload(edata) := x {
+	instance_postgresql_centralized_logging_payload_assert(edata, "<the argument to instance_postgresql_centralized_logging_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_postgresql_centralized_logging_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "pgaudit_enabled", concat("", [hint, ".", "pgaudit_enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_postgresql_centralized_logging_payload_assert_pgaudit_enabled(edata, "pgaudit_enabled", concat("", [hint, ".", "pgaudit_enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_postgresql_centralized_logging_payload_assert_pgaudit_enabled(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/sql/sql_instance_postgresql_log_connections.gen.rego
+++ b/decision/googlecloud/sql/sql_instance_postgresql_log_connections.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.sql
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that the log_connections database flag for Cloud SQL for PostgreSQL instance is set to On
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_sql_instance_postgresql_log_connections".
 instance_postgresql_log_connections(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_postgresql_log_connections_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ instance_postgresql_log_connections_allowed(h) {
 #     "log_connections_state": "example",
 #   }
 #   ```
-instance_postgresql_log_connections_payload(edata) = x {
+instance_postgresql_log_connections_payload(edata) := x {
+	instance_postgresql_log_connections_payload_assert(edata, "<the argument to instance_postgresql_log_connections_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_postgresql_log_connections_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "log_connections_state", concat("", [hint, ".", "log_connections_state"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_postgresql_log_connections_payload_assert_log_connections_state(edata, "log_connections_state", concat("", [hint, ".", "log_connections_state"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_postgresql_log_connections_payload_assert_log_connections_state(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/sql/sql_instance_postgresql_log_disconnections.gen.rego
+++ b/decision/googlecloud/sql/sql_instance_postgresql_log_disconnections.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.sql
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that the log_disconnections database flag for Cloud SQL for PostgreSQL instance is set to On
 # You can emit this decision as follows:
@@ -22,7 +26,7 @@ import data.shisho
 #     "allowed": allowed,
 #     "subject": subject,
 #     "payload": shisho.decision.googlecloud.sql.instance_postgresql_log_disconnections_payload({
-#       "log_disconnection_state": "example",
+#       "log_disconnections_state": "example",
 #     }),
 #   })
 # }
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_sql_instance_postgresql_log_disconnections".
 instance_postgresql_log_disconnections(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_postgresql_log_disconnections_header({
 			"allowed": d.allowed,
@@ -88,14 +93,29 @@ instance_postgresql_log_disconnections_allowed(h) {
 #   Emits a decision entry describing the detail of a decision decision.api.shisho.dev/v1beta:googlecloud_sql_instance_postgresql_log_disconnections
 #
 #   The parameter `data` is an object with the following fields: 
-#   - log_disconnection_state: string
+#   - log_disconnections_state: string
 #
 #   For instance, `data` can take the following value:
 #   ```rego
 #   {
-#     "log_disconnection_state": "example",
+#     "log_disconnections_state": "example",
 #   }
 #   ```
-instance_postgresql_log_disconnections_payload(edata) = x {
+instance_postgresql_log_disconnections_payload(edata) := x {
+	instance_postgresql_log_disconnections_payload_assert(edata, "<the argument to instance_postgresql_log_disconnections_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_postgresql_log_disconnections_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "log_disconnections_state", concat("", [hint, ".", "log_disconnections_state"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_postgresql_log_disconnections_payload_assert_log_disconnections_state(edata, "log_disconnections_state", concat("", [hint, ".", "log_disconnections_state"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_postgresql_log_disconnections_payload_assert_log_disconnections_state(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/sql/sql_instance_postgresql_log_error_verbosity.gen.rego
+++ b/decision/googlecloud/sql/sql_instance_postgresql_log_error_verbosity.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.sql
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure log_error_verbosity database flag for Cloud SQL for PostgreSQL instance is set to DEFAULT or stricter
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_sql_instance_postgresql_log_error_verbosity".
 instance_postgresql_log_error_verbosity(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_postgresql_log_error_verbosity_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ instance_postgresql_log_error_verbosity_allowed(h) {
 #     "log_error_verbosity_state": "example",
 #   }
 #   ```
-instance_postgresql_log_error_verbosity_payload(edata) = x {
+instance_postgresql_log_error_verbosity_payload(edata) := x {
+	instance_postgresql_log_error_verbosity_payload_assert(edata, "<the argument to instance_postgresql_log_error_verbosity_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_postgresql_log_error_verbosity_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "log_error_verbosity_state", concat("", [hint, ".", "log_error_verbosity_state"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_postgresql_log_error_verbosity_payload_assert_log_error_verbosity_state(edata, "log_error_verbosity_state", concat("", [hint, ".", "log_error_verbosity_state"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_postgresql_log_error_verbosity_payload_assert_log_error_verbosity_state(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/sql/sql_instance_postgresql_log_hostname.gen.rego
+++ b/decision/googlecloud/sql/sql_instance_postgresql_log_hostname.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.sql
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that the log_hostname database flag for Cloud SQL for PostgreSQL instance is set to on
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_sql_instance_postgresql_log_hostname".
 instance_postgresql_log_hostname(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_postgresql_log_hostname_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ instance_postgresql_log_hostname_allowed(h) {
 #     "log_hostname_state": "example",
 #   }
 #   ```
-instance_postgresql_log_hostname_payload(edata) = x {
+instance_postgresql_log_hostname_payload(edata) := x {
+	instance_postgresql_log_hostname_payload_assert(edata, "<the argument to instance_postgresql_log_hostname_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_postgresql_log_hostname_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "log_hostname_state", concat("", [hint, ".", "log_hostname_state"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_postgresql_log_hostname_payload_assert_log_hostname_state(edata, "log_hostname_state", concat("", [hint, ".", "log_hostname_state"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_postgresql_log_hostname_payload_assert_log_hostname_state(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/sql/sql_instance_postgresql_log_min_duration_statement.gen.rego
+++ b/decision/googlecloud/sql/sql_instance_postgresql_log_min_duration_statement.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.sql
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that the log_min_duration_statement database flag for Cloud SQL for PostgreSQL instance is set to -1
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_sql_instance_postgresql_log_min_duration_statement".
 instance_postgresql_log_min_duration_statement(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_postgresql_log_min_duration_statement_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ instance_postgresql_log_min_duration_statement_allowed(h) {
 #     "milliseconds_of_log_min_duration_statement": 0,
 #   }
 #   ```
-instance_postgresql_log_min_duration_statement_payload(edata) = x {
+instance_postgresql_log_min_duration_statement_payload(edata) := x {
+	instance_postgresql_log_min_duration_statement_payload_assert(edata, "<the argument to instance_postgresql_log_min_duration_statement_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_postgresql_log_min_duration_statement_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "milliseconds_of_log_min_duration_statement", concat("", [hint, ".", "milliseconds_of_log_min_duration_statement"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_postgresql_log_min_duration_statement_payload_assert_milliseconds_of_log_min_duration_statement(edata, "milliseconds_of_log_min_duration_statement", concat("", [hint, ".", "milliseconds_of_log_min_duration_statement"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_postgresql_log_min_duration_statement_payload_assert_milliseconds_of_log_min_duration_statement(x, key, hint) {
+	assertion.is_type(x[key], "number", hint)
+} else := false

--- a/decision/googlecloud/sql/sql_instance_postgresql_log_min_error_statement.gen.rego
+++ b/decision/googlecloud/sql/sql_instance_postgresql_log_min_error_statement.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.sql
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that the log_min_error_statement database flag for Cloud SQL for PostgreSQL instance is set to error or stricter
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_sql_instance_postgresql_log_min_error_statement".
 instance_postgresql_log_min_error_statement(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_postgresql_log_min_error_statement_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ instance_postgresql_log_min_error_statement_allowed(h) {
 #     "log_min_error_statement_state": "example",
 #   }
 #   ```
-instance_postgresql_log_min_error_statement_payload(edata) = x {
+instance_postgresql_log_min_error_statement_payload(edata) := x {
+	instance_postgresql_log_min_error_statement_payload_assert(edata, "<the argument to instance_postgresql_log_min_error_statement_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_postgresql_log_min_error_statement_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "log_min_error_statement_state", concat("", [hint, ".", "log_min_error_statement_state"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_postgresql_log_min_error_statement_payload_assert_log_min_error_statement_state(edata, "log_min_error_statement_state", concat("", [hint, ".", "log_min_error_statement_state"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_postgresql_log_min_error_statement_payload_assert_log_min_error_statement_state(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/sql/sql_instance_postgresql_log_min_messages.gen.rego
+++ b/decision/googlecloud/sql/sql_instance_postgresql_log_min_messages.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.sql
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that the log_min_messages database flag for Cloud SQL for PostgreSQL instance is set to at least warning
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_sql_instance_postgresql_log_min_messages".
 instance_postgresql_log_min_messages(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_postgresql_log_min_messages_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ instance_postgresql_log_min_messages_allowed(h) {
 #     "log_min_messages_state": "example",
 #   }
 #   ```
-instance_postgresql_log_min_messages_payload(edata) = x {
+instance_postgresql_log_min_messages_payload(edata) := x {
+	instance_postgresql_log_min_messages_payload_assert(edata, "<the argument to instance_postgresql_log_min_messages_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_postgresql_log_min_messages_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "log_min_messages_state", concat("", [hint, ".", "log_min_messages_state"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_postgresql_log_min_messages_payload_assert_log_min_messages_state(edata, "log_min_messages_state", concat("", [hint, ".", "log_min_messages_state"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_postgresql_log_min_messages_payload_assert_log_min_messages_state(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/sql/sql_instance_postgresql_log_statement.gen.rego
+++ b/decision/googlecloud/sql/sql_instance_postgresql_log_statement.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.sql
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that the log_statement database flag for Cloud SQL for PostgreSQL instance is set appropriately
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_sql_instance_postgresql_log_statement".
 instance_postgresql_log_statement(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_postgresql_log_statement_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ instance_postgresql_log_statement_allowed(h) {
 #     "log_statement_state": "example",
 #   }
 #   ```
-instance_postgresql_log_statement_payload(edata) = x {
+instance_postgresql_log_statement_payload(edata) := x {
+	instance_postgresql_log_statement_payload_assert(edata, "<the argument to instance_postgresql_log_statement_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_postgresql_log_statement_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "log_statement_state", concat("", [hint, ".", "log_statement_state"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_postgresql_log_statement_payload_assert_log_statement_state(edata, "log_statement_state", concat("", [hint, ".", "log_statement_state"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_postgresql_log_statement_payload_assert_log_statement_state(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/sql/sql_instance_public_ip.gen.rego
+++ b/decision/googlecloud/sql/sql_instance_public_ip.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.sql
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure Cloud SQL instances have public IPs only if they need
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_sql_instance_public_ip".
 instance_public_ip(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_public_ip_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ instance_public_ip_allowed(h) {
 #     "has_public_ip": false,
 #   }
 #   ```
-instance_public_ip_payload(edata) = x {
+instance_public_ip_payload(edata) := x {
+	instance_public_ip_payload_assert(edata, "<the argument to instance_public_ip_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_public_ip_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "has_public_ip", concat("", [hint, ".", "has_public_ip"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_public_ip_payload_assert_has_public_ip(edata, "has_public_ip", concat("", [hint, ".", "has_public_ip"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_public_ip_payload_assert_has_public_ip(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/googlecloud/sql/sql_instance_sqlserver_3625_trace_flag.gen.rego
+++ b/decision/googlecloud/sql/sql_instance_sqlserver_3625_trace_flag.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.sql
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that the 3625 (trace flag) database flag for all Cloud SQL for SQL Server instances is set to off
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_sql_instance_sqlserver_3625_trace_flag".
 instance_sqlserver_3625_trace_flag(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_sqlserver_3625_trace_flag_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ instance_sqlserver_3625_trace_flag_allowed(h) {
 #     "trace_flag_state": "example",
 #   }
 #   ```
-instance_sqlserver_3625_trace_flag_payload(edata) = x {
+instance_sqlserver_3625_trace_flag_payload(edata) := x {
+	instance_sqlserver_3625_trace_flag_payload_assert(edata, "<the argument to instance_sqlserver_3625_trace_flag_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_sqlserver_3625_trace_flag_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "trace_flag_state", concat("", [hint, ".", "trace_flag_state"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_sqlserver_3625_trace_flag_payload_assert_trace_flag_state(edata, "trace_flag_state", concat("", [hint, ".", "trace_flag_state"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_sqlserver_3625_trace_flag_payload_assert_trace_flag_state(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/sql/sql_instance_sqlserver_contained_db_authentication.gen.rego
+++ b/decision/googlecloud/sql/sql_instance_sqlserver_contained_db_authentication.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.sql
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that the contained_db_authentication_state  database flag a Cloud SQL for SQL Server instance is set to off
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_sql_instance_sqlserver_contained_db_authentication".
 instance_sqlserver_contained_db_authentication(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_sqlserver_contained_db_authentication_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ instance_sqlserver_contained_db_authentication_allowed(h) {
 #     "contained_db_authentication_state": "example",
 #   }
 #   ```
-instance_sqlserver_contained_db_authentication_payload(edata) = x {
+instance_sqlserver_contained_db_authentication_payload(edata) := x {
+	instance_sqlserver_contained_db_authentication_payload_assert(edata, "<the argument to instance_sqlserver_contained_db_authentication_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_sqlserver_contained_db_authentication_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "contained_db_authentication_state", concat("", [hint, ".", "contained_db_authentication_state"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_sqlserver_contained_db_authentication_payload_assert_contained_db_authentication_state(edata, "contained_db_authentication_state", concat("", [hint, ".", "contained_db_authentication_state"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_sqlserver_contained_db_authentication_payload_assert_contained_db_authentication_state(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/sql/sql_instance_sqlserver_cross_db_ownership_chaining.gen.rego
+++ b/decision/googlecloud/sql/sql_instance_sqlserver_cross_db_ownership_chaining.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.sql
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that the cross_db_ownership_chaining_state  database flag for a Cloud SQL for SQL Server instance is set to off
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_sql_instance_sqlserver_cross_db_ownership_chaining".
 instance_sqlserver_cross_db_ownership_chaining(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_sqlserver_cross_db_ownership_chaining_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ instance_sqlserver_cross_db_ownership_chaining_allowed(h) {
 #     "cross_db_ownership_chaining_state": "example",
 #   }
 #   ```
-instance_sqlserver_cross_db_ownership_chaining_payload(edata) = x {
+instance_sqlserver_cross_db_ownership_chaining_payload(edata) := x {
+	instance_sqlserver_cross_db_ownership_chaining_payload_assert(edata, "<the argument to instance_sqlserver_cross_db_ownership_chaining_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_sqlserver_cross_db_ownership_chaining_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "cross_db_ownership_chaining_state", concat("", [hint, ".", "cross_db_ownership_chaining_state"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_sqlserver_cross_db_ownership_chaining_payload_assert_cross_db_ownership_chaining_state(edata, "cross_db_ownership_chaining_state", concat("", [hint, ".", "cross_db_ownership_chaining_state"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_sqlserver_cross_db_ownership_chaining_payload_assert_cross_db_ownership_chaining_state(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/sql/sql_instance_sqlserver_external_scripts.gen.rego
+++ b/decision/googlecloud/sql/sql_instance_sqlserver_external_scripts.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.sql
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure cross_db_ownership_chaining_state database flag for a Cloud SQL for SQL Server instance is set to off
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_sql_instance_sqlserver_external_scripts".
 instance_sqlserver_external_scripts(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_sqlserver_external_scripts_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ instance_sqlserver_external_scripts_allowed(h) {
 #     "external_scripts_state": "example",
 #   }
 #   ```
-instance_sqlserver_external_scripts_payload(edata) = x {
+instance_sqlserver_external_scripts_payload(edata) := x {
+	instance_sqlserver_external_scripts_payload_assert(edata, "<the argument to instance_sqlserver_external_scripts_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_sqlserver_external_scripts_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "external_scripts_state", concat("", [hint, ".", "external_scripts_state"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_sqlserver_external_scripts_payload_assert_external_scripts_state(edata, "external_scripts_state", concat("", [hint, ".", "external_scripts_state"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_sqlserver_external_scripts_payload_assert_external_scripts_state(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/sql/sql_instance_sqlserver_remote_access.gen.rego
+++ b/decision/googlecloud/sql/sql_instance_sqlserver_remote_access.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.sql
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure that the remote_access_state database flag for a Cloud SQL for SQL Server instance is set to off
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_sql_instance_sqlserver_remote_access".
 instance_sqlserver_remote_access(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_sqlserver_remote_access_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ instance_sqlserver_remote_access_allowed(h) {
 #     "remote_access_state": "example",
 #   }
 #   ```
-instance_sqlserver_remote_access_payload(edata) = x {
+instance_sqlserver_remote_access_payload(edata) := x {
+	instance_sqlserver_remote_access_payload_assert(edata, "<the argument to instance_sqlserver_remote_access_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_sqlserver_remote_access_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "remote_access_state", concat("", [hint, ".", "remote_access_state"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_sqlserver_remote_access_payload_assert_remote_access_state(edata, "remote_access_state", concat("", [hint, ".", "remote_access_state"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_sqlserver_remote_access_payload_assert_remote_access_state(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/sql/sql_instance_sqlserver_user_connections.gen.rego
+++ b/decision/googlecloud/sql/sql_instance_sqlserver_user_connections.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.sql
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure maximum_user_connections database flag for a Cloud SQL for SQL Server instance is set to a non-limiting value
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_sql_instance_sqlserver_user_connections".
 instance_sqlserver_user_connections(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_sqlserver_user_connections_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ instance_sqlserver_user_connections_allowed(h) {
 #     "maximum_user_connections": 0,
 #   }
 #   ```
-instance_sqlserver_user_connections_payload(edata) = x {
+instance_sqlserver_user_connections_payload(edata) := x {
+	instance_sqlserver_user_connections_payload_assert(edata, "<the argument to instance_sqlserver_user_connections_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_sqlserver_user_connections_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "maximum_user_connections", concat("", [hint, ".", "maximum_user_connections"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_sqlserver_user_connections_payload_assert_maximum_user_connections(edata, "maximum_user_connections", concat("", [hint, ".", "maximum_user_connections"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_sqlserver_user_connections_payload_assert_maximum_user_connections(x, key, hint) {
+	assertion.is_type(x[key], "number", hint)
+} else := false

--- a/decision/googlecloud/sql/sql_instance_sqlserver_user_options.gen.rego
+++ b/decision/googlecloud/sql/sql_instance_sqlserver_user_options.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.sql
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure user_options_configured database flag for a Cloud SQL for SQL Server instance is not configured
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_sql_instance_sqlserver_user_options".
 instance_sqlserver_user_options(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": instance_sqlserver_user_options_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ instance_sqlserver_user_options_allowed(h) {
 #     "user_options_configured": false,
 #   }
 #   ```
-instance_sqlserver_user_options_payload(edata) = x {
+instance_sqlserver_user_options_payload(edata) := x {
+	instance_sqlserver_user_options_payload_assert(edata, "<the argument to instance_sqlserver_user_options_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+instance_sqlserver_user_options_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "user_options_configured", concat("", [hint, ".", "user_options_configured"]))]
+	every c in key_checks { c }
+
+	value_checks := [instance_sqlserver_user_options_payload_assert_user_options_configured(edata, "user_options_configured", concat("", [hint, ".", "user_options_configured"]))]
+	every c in value_checks { c }
+} else := false
+
+instance_sqlserver_user_options_payload_assert_user_options_configured(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/googlecloud/storage/storage_bucket_accessibility.gen.rego
+++ b/decision/googlecloud/storage/storage_bucket_accessibility.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.storage
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure Cloud Storage buckets are public only if intended
 # You can emit this decision as follows:
@@ -22,7 +26,7 @@ import data.shisho
 #     "allowed": allowed,
 #     "subject": subject,
 #     "payload": shisho.decision.googlecloud.storage.bucket_accessibility_payload({
-#       "public_acl_rules": [{"role": "example", "principal": "example"}],
+#       "public_acl_rules": [{"role": "example", "entity": "example"}],
 #       "public_policy_bindings": [{"role": "example", "principal": "example"}],
 #     }),
 #   })
@@ -35,6 +39,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_storage_bucket_accessibility".
 bucket_accessibility(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": bucket_accessibility_header({
 			"allowed": d.allowed,
@@ -89,16 +94,103 @@ bucket_accessibility_allowed(h) {
 #   Emits a decision entry describing the detail of a decision decision.api.shisho.dev/v1beta:googlecloud_storage_bucket_accessibility
 #
 #   The parameter `data` is an object with the following fields: 
-#   - public_acl_rules: {"role": string, "principal": string}
+#   - public_acl_rules: {"role": string, "entity": string}
 #   - public_policy_bindings: {"role": string, "principal": string}
 #
 #   For instance, `data` can take the following value:
 #   ```rego
 #   {
-#     "public_acl_rules": [{"role": "example", "principal": "example"}],
+#     "public_acl_rules": [{"role": "example", "entity": "example"}],
 #     "public_policy_bindings": [{"role": "example", "principal": "example"}],
 #   }
 #   ```
-bucket_accessibility_payload(edata) = x {
+bucket_accessibility_payload(edata) := x {
+	bucket_accessibility_payload_assert(edata, "<the argument to bucket_accessibility_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+bucket_accessibility_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [
+		assertion.has_key(edata, "public_acl_rules", concat("", [hint, ".", "public_acl_rules"])),
+		assertion.has_key(edata, "public_policy_bindings", concat("", [hint, ".", "public_policy_bindings"])),
+	]
+	every c in key_checks { c }
+
+	value_checks := [
+		bucket_accessibility_payload_assert_public_acl_rules(edata, "public_acl_rules", concat("", [hint, ".", "public_acl_rules"])),
+		bucket_accessibility_payload_assert_public_policy_bindings(edata, "public_policy_bindings", concat("", [hint, ".", "public_policy_bindings"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+bucket_accessibility_payload_assert_public_acl_rules(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [bucket_accessibility_payload_assert_public_acl_rules_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+bucket_accessibility_payload_assert_public_acl_rules_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "role", "string", hint),
+		assertion.has_typed_key(x[key], "entity", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		bucket_accessibility_payload_assert_public_acl_rules_element_role(x[key], "role", concat("", [hint, ".", "role"])),
+		bucket_accessibility_payload_assert_public_acl_rules_element_entity(x[key], "entity", concat("", [hint, ".", "entity"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+bucket_accessibility_payload_assert_public_acl_rules_element_entity(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+bucket_accessibility_payload_assert_public_acl_rules_element_role(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+bucket_accessibility_payload_assert_public_policy_bindings(x, key, hint) {
+	assertion.is_set_or_array(x[key], hint)
+	checks := [bucket_accessibility_payload_assert_public_policy_bindings_element(x[key], i, concat("", [
+		hint,
+		"[",
+		format_int(i, 10),
+		"]",
+	])) |
+		_ := x[key][i]
+	]
+	every c in checks { c }
+} else := false
+
+bucket_accessibility_payload_assert_public_policy_bindings_element(x, key, hint) {
+	assertion.is_type(x[key], "object", hint)
+	key_checks := [
+		assertion.has_typed_key(x[key], "role", "string", hint),
+		assertion.has_typed_key(x[key], "principal", "string", hint),
+	]
+	every c in key_checks { c }
+	value_checks := [
+		bucket_accessibility_payload_assert_public_policy_bindings_element_role(x[key], "role", concat("", [hint, ".", "role"])),
+		bucket_accessibility_payload_assert_public_policy_bindings_element_principal(x[key], "principal", concat("", [hint, ".", "principal"])),
+	]
+	every c in value_checks { c }
+} else := false
+
+bucket_accessibility_payload_assert_public_policy_bindings_element_principal(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false
+
+bucket_accessibility_payload_assert_public_policy_bindings_element_role(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/googlecloud/support/support_access_approval.gen.rego
+++ b/decision/googlecloud/support/support_access_approval.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.support
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure Access Approval is enabled
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_support_access_approval".
 access_approval(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": access_approval_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ access_approval_allowed(h) {
 #     "enabled": false,
 #   }
 #   ```
-access_approval_payload(edata) = x {
+access_approval_payload(edata) := x {
+	access_approval_payload_assert(edata, "<the argument to access_approval_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+access_approval_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "enabled", concat("", [hint, ".", "enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [access_approval_payload_assert_enabled(edata, "enabled", concat("", [hint, ".", "enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+access_approval_payload_assert_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/googlecloud/support/support_access_transparency.gen.rego
+++ b/decision/googlecloud/support/support_access_transparency.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.googlecloud.support
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Ensure Access Transparency is enabled
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:googlecloud_support_access_transparency".
 access_transparency(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": access_transparency_header({
 			"allowed": d.allowed,
@@ -96,6 +101,21 @@ access_transparency_allowed(h) {
 #     "enabled": false,
 #   }
 #   ```
-access_transparency_payload(edata) = x {
+access_transparency_payload(edata) := x {
+	access_transparency_payload_assert(edata, "<the argument to access_transparency_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+access_transparency_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "enabled", concat("", [hint, ".", "enabled"]))]
+	every c in key_checks { c }
+
+	value_checks := [access_transparency_payload_assert_enabled(edata, "enabled", concat("", [hint, ".", "enabled"]))]
+	every c in value_checks { c }
+} else := false
+
+access_transparency_payload_assert_enabled(x, key, hint) {
+	assertion.is_type(x[key], "boolean", hint)
+} else := false

--- a/decision/source/source.gen.rego
+++ b/decision/source/source.gen.rego
@@ -4,6 +4,10 @@
 package shisho.decision.source
 
 import data.shisho
+import data.shisho.assertion
+import data.shisho.primitive
+
+import future.keywords.every
 
 # @title Manage sources with a version control system
 # You can emit this decision as follows:
@@ -34,6 +38,7 @@ import data.shisho
 # description: |
 #   Emits a decision whose type is decision.api.shisho.dev/v1beta:version_control".
 version_control(d) = x {
+	shisho.decision.has_required_fields(d)
 	x := {
 		"header": version_control_header({
 			"allowed": d.allowed,
@@ -95,6 +100,21 @@ version_control_allowed(h) {
 #     "type": "example",
 #   }
 #   ```
-version_control_payload(edata) = x {
+version_control_payload(edata) := x {
+	version_control_payload_assert(edata, "<the argument to version_control_payload>")
 	x := json.marshal(edata)
-}
+} else := ""
+
+version_control_payload_assert(edata, hint) {
+	assertion.is_type(edata, "object", hint)
+
+	key_checks := [assertion.has_key(edata, "type", concat("", [hint, ".", "type"]))]
+	every c in key_checks { c }
+
+	value_checks := [version_control_payload_assert_type(edata, "type", concat("", [hint, ".", "type"]))]
+	every c in value_checks { c }
+} else := false
+
+version_control_payload_assert_type(x, key, hint) {
+	assertion.is_type(x[key], "string", hint)
+} else := false

--- a/decision/validation.rego
+++ b/decision/validation.rego
@@ -1,0 +1,21 @@
+package shisho.decision
+
+import data.shisho.assertion
+import future.keywords.every
+
+has_required_fields(d) {
+	checks := [
+		assertion.has_typed_key(d, "allowed", "boolean", concat("", ["d.allowed"])),
+		assertion.has_typed_key(d, "subject", "string", concat("", ["d.subject"])),
+		has_serialized_payload(d),
+	]
+	every c in checks { c }
+}
+
+has_serialized_payload(d) := false {
+	not is_string(d.payload)
+	print(concat("", ["validation error: type mismatch: d.payload (expected string, got ", type_name(d.payload), ")"]))
+} else := false {
+	d.payload == ""
+	print("validation error: payload must not be empty")
+} else := true

--- a/primitive/typing.rego
+++ b/primitive/typing.rego
@@ -1,0 +1,33 @@
+package shisho.primitive
+
+is_type(x, ty) := is_array(x) {
+	ty == "array"
+} else := is_boolean(x) {
+	ty == "boolean"
+} else := is_null(x) {
+	ty == "null"
+} else := is_object(x) {
+	ty == "object"
+} else := is_set(x) {
+	ty == "set"
+} else := is_string(x) {
+	ty == "string"
+} else := is_number(x) {
+	ty == "number"
+} else := false
+
+is_set_or_array(x) {
+	is_set(x)
+} else {
+	is_array(x)
+} else := false
+
+is_set_or_object(x) {
+	is_set(x)
+} else {
+	is_object(x)
+} else := false
+
+has_key(x, k) {
+	_ = x[k]
+} else := false


### PR DESCRIPTION
This PR implements validation for managed decision payloads. Now Rego policies will fail when your implementation violates assumptions on each payload (e.g. it fails to report required evidence for each finding).